### PR TITLE
docs: Fix spelling errors in documentation

### DIFF
--- a/docs/agent-in-depth.md
+++ b/docs/agent-in-depth.md
@@ -1,26 +1,26 @@
 # Akri Agent
 The Akri Agent executes on all worker Nodes in the cluster.  It is primarily tasked with:
 
-1. Handling capability availabiity changes
-1. Enabling capability sharing
+1. Handling resource availability changes
+1. Enabling resource sharing
 
-These two tasks enable Akri to find configured capabilities, expose them to the Kubernetes cluster for workload scheduling, and allow capabilities to be shared by multiple Nodes.
+These two tasks enable Akri to find configured resources (leaf devices), expose them to the Kubernetes cluster for workload scheduling, and allow resources to be shared by multiple Nodes.
 
-## Handling capability availabiity changes
-The first step in handling capability availability is determining what capabilities to look for.  This is accomplished by finding existing Configurations and watching for changes to them.
+## Handling resource availability changes
+The first step in handling resource availability is determining what resources (leaf devices) to look for.  This is accomplished by finding existing Configurations and watching for changes to them.
 
-Once the Akri Agent understands what capabilities to look for (via `Configuration.protocol`), it will find any capabilities that are visible.
+Once the Akri Agent understands what resources to look for (via `Configuration.protocol`), it will find any resources that are visible.
 
-For each capability that is found:
+For each resource that is found:
 
 1. An Instance is created and uploaded to etcd
-1. A connection with Kubelet is established according to the Kubernetes Device Plugin framework.  This connection is used to convey availability changes to Kubelet.  Kubelet will, in turn, expose these availability changes to the Kubernetes scheduler.
+1. A connection with the kubelet is established according to the Kubernetes Device Plugin framework.  This connection is used to convey availability changes to the kubelet. The kubelet will, in turn, expose these availability changes to the Kubernetes scheduler.
 
-Each protocol will periodically reassess what capabilities are visible and update both the Instance and Kubelet with the current availability.
+Each protocol will periodically reassess what resources are visible and update both the Instance and the kubelet with the current availability.
 
-This process allows Akri to dynamically represent capabilities that appear and disappear.
+This process allows Akri to dynamically represent resources that appear and disappear.
 
-## Enabling capability sharing
-To enable capability sharing, the Akri Agent creates and updates the `Instance.deviceUsage` map and communicates with Kubelet.  The `DeviceCapabiltiyInstance.deviceUsage` map is used to coordinate between Nodes.  The Kubelet communication allows Akri Agent to communicate any capability availabilty changes to the Kubernetes scheduler.
+## Enabling resource sharing
+To enable resource sharing, the Akri Agent creates and updates the `Instance.deviceUsage` map and communicates with kubelet.  The `Instance.deviceUsage` map is used to coordinate between Nodes.  The kubelet communication allows Akri Agent to communicate any resource availability changes to the Kubernetes scheduler.
 
-For more detailed information, see the [in-depth capability sharing doc](./capability-sharing-in-depth.md).
+For more detailed information, see the [in-depth resource sharing doc](./resource-sharing-in-depth.md).

--- a/docs/controller-in-depth.md
+++ b/docs/controller-in-depth.md
@@ -1,17 +1,17 @@
 # Akri Controller
 The Akri Controller executes on the master Node in the cluster.  It is primarily tasked with:
 
-1. Enabling cluster access to capabilities
+1. Enabling cluster access to leaf devices
 1. Handling node disappearances
 
-These tasks enable Akri to provide capabilities with high availability, while allowing the Kubernetes application to be agnostic about what specific Nodes or Pods are executing at any given moment.
+These tasks enable Akri to provide resources with high availability, while allowing the Kubernetes application to be agnostic about what specific Nodes or Pods are executing at any given moment.
 
-## Enabling cluster access to capabilities
-The first step to enable cluster access to capabilities is, of course, finding them.  The work of discoverying capabilities and making them known to the Kubernetes cluster is handled by the [Akri Agent](./agent-in-depth.md).  The Akri Agents ensure that Instances are created and updated to enforce capability sharing.
+## Enabling cluster access to resources
+The first step to enable cluster access to resources (leaf devices) is, of course, finding them.  The work of discovering resources and making them known to the Kubernetes cluster is handled by the [Akri Agent](./agent-in-depth.md).  The Akri Agents ensure that Instances are created and updated to enforce capability sharing.
 
 Once a capability has been discovered and Instances are created, it is up to the Akri Controller to provide cluster access.
 
-To provide access to discovered capabilities, the Akri Controller works to ensure that the Pods and Services described in the relevant Configuration are running.  This is accomplished by listening for changes, additions, and deletions of Instances.
+To provide access to discovered resources, the Akri Controller works to ensure that the Pods and Services described in the relevant Configuration are running.  This is accomplished by listening for changes, additions, and deletions of Instances.
 
 When an instance is created or updated, the Akri Controller needs to do several things:
 
@@ -26,4 +26,4 @@ When an instance is deleted, the Akri Controller needs to do several things:
 1. Ensure that the capability Service based on `Configuration.configurationServiceSpec` is removed, if there are no Pods supporting the Service (note that many instances can contribute supporting Pods to a given configuration)
 
 ## Handling node disappearances
-One of the conditions we need to be aware of is node disappearance.  In this case, we cannot depend on the disappeared node's Akri Agent to modify the relevant Instance.  To free up any `Configuration.capacity` that a node was using prior to disappering, the Akri Controller watches for Node disappearance events and cleans up any lingering node references in any `Instance.nodes` and `Instance.deviceUsage`.
+One of the conditions we need to be aware of is node disappearance.  In this case, we cannot depend on the disappeared node's Akri Agent to modify the relevant Instance.  To free up any `Configuration.capacity` that a node was using prior to disappearing, the Akri Controller watches for Node disappearance events and cleans up any lingering node references in any `Instance.nodes` and `Instance.deviceUsage`.

--- a/docs/proposals/opcua.md
+++ b/docs/proposals/opcua.md
@@ -26,7 +26,7 @@ maintains a list of OPC UA Servers that are available on the network and provide
 list”.<sup>1</sup> A LocalDiscoveryServer is a DiscoveryServer implementation, which usually runs on a host at the URL
 `opc.tcp://localhost:4840/UADiscovery` for TCP.<sup>2</sup> An LDS maintains a list of all servers that have
 **registered with it**, which are usually servers running on the same host. An operator can specify a list of
-DiscoveryURLs for LDSes in the OPC UA Configuration. 
+DiscoveryURLs for LDSs in the OPC UA Configuration. 
 
 **Note**: Agent's `OpcuaDiscoveryMethod::standard`, which does
 both of the discovery via Server DiscoveryURLs and discovery via a Local Discovery Server listed above, only supports

--- a/docs/proposals/simple-protocol-extension.md
+++ b/docs/proposals/simple-protocol-extension.md
@@ -3,7 +3,7 @@
 ## Background
 All protocol discovery is currently implemented in each Akri Agent. This is a simple model, but one can imagine some drawbacks:
 
-1. Potentially, this can make each Agent bigger than it needs to be.  For example, Agent contains implements for ONVIF, udev, and OPCUA discovery … but someone may simply want OPCUA.
+1. Potentially, this can make each Agent bigger than it needs to be.  For example, Agent contains implementations for ONVIF, udev discovery … but someone may simply want ONVIF.
 1. Choosing what protocols are distributed is a build-time decision.  If someone only expected to use the udev implementation, they would need to rebuild Agent, excluding the other protocols.
 1. Implementing a new protocol requires changes to Agent.  To add a Foo protocol, the Configuration CRD needs to be changed, Agent's Configuration parsing/handling code needs to be changed, and Agent needs to implement discovery for Foo.
 
@@ -40,5 +40,5 @@ Wouldn't it be great if users could deploy only the implementations they wanted?
     ```
 
 ### Issues
-* The Akri.Configuration CRD, which Agent parses, explicitly describes all possible protocols.  The protocol definition will need to change to be more genericly parsable (maybe to a named property list, where the name is the protocol)
+* The Akri.Configuration CRD, which Agent parses, explicitly describes all possible protocols.  The protocol definition will need to change to be more generically parsable (maybe to a named property list, where the name is the protocol)
 * Rust doesn't have a built-in plug-in system

--- a/docs/resource-sharing-in-depth.md
+++ b/docs/resource-sharing-in-depth.md
@@ -34,7 +34,7 @@ During this initialization, a separate, but similar, mapping is sent to the kube
     my-resource-00095f-4: "Healthy"
 ```
 
-When the kubelet attempts to schedule a workload on a specific Node, that Node's Akri Agent will be queried with a slot name (this slot name is chosen by the kubelet from the mapping list that Akri Agent sent it).  Akri Agent will query the appropriate Instance to see if that resource is still visisble and if the mapping for that slot is still empty.  If both of these requirements are met, then the Akri Agent will update the `Instance.deviceUsage` map to claim the slot, and will allow the kubelet to schedule its intended workload.  After this, the `Instance.deviceUsage` may look something like this:
+When the kubelet attempts to schedule a workload on a specific Node, that Node's Akri Agent will be queried with a slot name (this slot name is chosen by the kubelet from the mapping list that Akri Agent sent it).  Akri Agent will query the appropriate Instance to see if that resource is still visible and if the mapping for that slot is still empty.  If both of these requirements are met, then the Akri Agent will update the `Instance.deviceUsage` map to claim the slot, and will allow the kubelet to schedule its intended workload.  After this, the `Instance.deviceUsage` may look something like this:
 
 ```yaml
   deviceUsage:
@@ -59,7 +59,7 @@ These two steps will ensure that a specific slot is only used by one Node.
 
 There is a possible race condition here.  What happens if Kubernetes tries to schedule a workload after the `Instance.deviceUsage` slot has been claimed, but before other Nodes have reported the slot as Unhealthy?
 
-In this case, we can depend on the Instance as the truth.  If the kubelet sends a query with a slot name that is claimed by another node in `DevicresourceInstance.deviceUsage`, an error is returned to the kubelet and the workload will not be scheduled.
+In this case, we can depend on the Instance as the truth.  If the kubelet sends a query with a slot name that is claimed by another node in `Instance.deviceUsage`, an error is returned to the kubelet and the workload will not be scheduled.
 
 ### Special case: workload disappearance
 There is one case that is not addressed above: when a workload fails, finishes, or generally no longer exists.  In this case, the slot that the workload claimed needs to be released.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,7 +19,6 @@ for more details.
 ### Prioritization of protocols to support
 1. OPC UA (to discovery OPC UA Servers) 
     - [Proposal uploaded](./proposals/opcua.md)
-    - Working end to end solution in [opcua branch](https://github.com/deislabs/akri/tree/opcua) has yet to be merged into main
 1. MQTT
 1. Bluetooth
 1. AMQP

--- a/docs/rpi4-demo.md
+++ b/docs/rpi4-demo.md
@@ -1,5 +1,5 @@
 # Raspberry Pi 4 Demo   
-This demo will demonstrate how to get Akri working on a **Raspberry Pi 4**, all the way from discovering local video cameras to the footage being streamed on a web application. This will show how akri can dynamically discover devices, deploy brokers pods to perform some action on a device (in this case grabing video frames and serving them over gRPC), and deploy broker services for obtaining the results of that action.
+This demo will demonstrate how to get Akri working on a **Raspberry Pi 4**, all the way from discovering local video cameras to the footage being streamed on a web application. This will show how Akri can dynamically discover devices, deploy brokers pods to perform some action on a device (in this case grabbing video frames and serving them over gRPC), and deploy broker services for obtaining the results of that action.
 
 ## Set up single node cluster on a Raspberry Pi 4
 1. Using instructions found [here](https://ubuntu.com/download/raspberry-pi), download 64-bit Ubuntu:18.04
@@ -79,7 +79,7 @@ This demo will demonstrate how to get Akri working on a **Raspberry Pi 4**, all 
     ```
     Run `kubectl get crd`, and you should see the crds listed.
     Run `kubectl get pods -o wide`, and you should see the Akri pods.
-    Run `kubectl get akric`, and you should see `akri-udev-video`. If IP cameras were discovered and pods spun up, the instances can be seen by running `kubectl get akrii` and further inspected by runing `kubectl get akrii akri-udev-video-<ID> -o yaml`
+    Run `kubectl get akric`, and you should see `akri-udev-video`. If IP cameras were discovered and pods spun up, the instances can be seen by running `kubectl get akrii` and further inspected by running `kubectl get akrii akri-udev-video-<ID> -o yaml`
 
 1. Inspect the two instances, seeing that the correct devnodes in the metadata and that one of the usage slots for each instance was reseved for this node.
     ```sh 

--- a/docs/udev-sample.md
+++ b/docs/udev-sample.md
@@ -62,7 +62,7 @@ The `brokerPodSpec` property is a full [PodSpec](https://kubernetes.io/docs/refe
     --set udevVideo.brokerPod.env.fps=30
 ```
 
-**Note:** that udev broker pods must run as priveleged in order for udev to be able to access the video device.
+**Note:** that udev broker pods must run as privileged in order for udev to be able to access the video device.
 
 Reference [Modifying a Akri Installation](./modifying-akri-installation#modifying-the-brokerpodspec)) for more examples of how the broker spec can be modified. 
 


### PR DESCRIPTION
Fixed simple typos in the documentation using this [Code Spell Checker](https://marketplace.visualstudio.com/items?itemName=streetsidesoftware.code-spell-checker). Also, changed "resource" to "capability" in `agent-in-depth.md` and `controller-in-depth.md`.