### PR TITLE
Add documentation for enabling Akri to connect to k3s and MicroK8s CNI

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,4 +132,4 @@ For a more in-depth understanding, see [Controller In-depth](./controller-in-dep
       nodes:
       - "<this-node>"
     ```
-1. Allocate will return `false` if kubelet requests a `deviceUsage` slot that is already taken. See the [resource sharing document](./resource-sharing-in-depth#instance.deviceUsage) for a better understanding on how this is resolved. Otherwise, upon a `true` result, the kubelet will run the pod. The broker is now running and has the information necessary to communicate with the specific device. 
+1. Allocate will return `false` if kubelet requests a `deviceUsage` slot that is already taken. See the [resource sharing document](./resource-sharing-in-depth.md#instancedeviceusage) for a better understanding on how this is resolved. Otherwise, upon a `true` result, the kubelet will run the pod. The broker is now running and has the information necessary to communicate with the specific device. 

--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -33,6 +33,10 @@ carry out one or the other, then continue on with the rest of the steps.
     ```sh
     kubectl label node ${HOSTNAME,,} node-role.kubernetes.io/master= --overwrite=true
     ```
+1. K3s uses its own embedded crictl, so we need to configure the Akri Helm chart with the k3s crictl path and socket
+    ```sh
+    export AKRI_HELM_CRICTL_CONFIGURATION="--set agent.host.crictl=/usr/local/bin/crictl --set agent.host.dockerShimSock=/run/k3s/containerd/containerd.sock"
+    ```
 
 ## Option 2: Set up single node cluster using MicroK8s
 1. Acquire an Ubuntu 20.04 LTS, 18.04 LTS or 16.04 LTS environment to run the commands.
@@ -82,6 +86,16 @@ carry out one or the other, then continue on with the rest of the steps.
     ```sh
     kubectl label node ${HOSTNAME,,} node-role.kubernetes.io/master= --overwrite=true
     ```
+1. Akri depends on crictl to track some Pod information and becase Microk8s does not install crictl locally, crictl must be installed and the Akri Helm chart needs to be configured with the crictl path and Microk8s containerd socket
+    ```sh
+    # Note that we aren't aware of any version restrictions
+    VERSION="v1.17.0"
+    curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
+    sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+    rm -f crictl-$VERSION-linux-amd64.tar.gz
+
+    export AKRI_HELM_CRICTL_CONFIGURATION="--set agent.host.crictl=/usr/local/bin/crictl --set agent.host.dockerShimSock=/var/snap/microk8s/common/run/containerd.sock"
+    ```
 
 ## Set up mock udev video devices
 1. Install a kernel module to make v4l2 loopback video devices. Learn more about this module [here](https://github.com/umlaeute/v4l2loopback).
@@ -119,6 +133,7 @@ carry out one or the other, then continue on with the rest of the steps.
     ```sh
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
     helm install akri akri-helm-charts/akri \
+        $AKRI_HELM_CRICTL_CONFIGURATION \
         --set useLatestContainers=true \
         --set udevVideo.enabled=true \
         --set udevVideo.udevRules[0]='KERNEL==\"video[0-9]*\"'

--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -33,7 +33,7 @@ carry out one or the other, then continue on with the rest of the steps.
     ```sh
     kubectl label node ${HOSTNAME,,} node-role.kubernetes.io/master= --overwrite=true
     ```
-1. K3s uses its own embedded crictl, so we need to configure the Akri Helm chart with the k3s crictl path and socket
+1. K3s uses its own embedded crictl, so we need to configure the Akri Helm chart with the k3s crictl path and socket.
     ```sh
     export AKRI_HELM_CRICTL_CONFIGURATION="--set agent.host.crictl=/usr/local/bin/crictl --set agent.host.dockerShimSock=/run/k3s/containerd/containerd.sock"
     ```
@@ -86,7 +86,7 @@ carry out one or the other, then continue on with the rest of the steps.
     ```sh
     kubectl label node ${HOSTNAME,,} node-role.kubernetes.io/master= --overwrite=true
     ```
-1. Akri depends on crictl to track some Pod information and becase Microk8s does not install crictl locally, crictl must be installed and the Akri Helm chart needs to be configured with the crictl path and Microk8s containerd socket
+1. Akri depends on crictl to track some Pod information. MicroK8s does not install crictl locally, so crictl must be installed and the Akri Helm chart needs to be configured with the crictl path and MicroK8s containerd socket.
     ```sh
     # Note that we aren't aware of any version restrictions
     VERSION="v1.17.0"

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -64,6 +64,7 @@ kubectl label node $HOSTNAME node-role.kubernetes.io/master= --overwrite=true
     ```sh
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
     helm install akri akri-helm-charts/akri \
+        $AKRI_HELM_CRICTL_CONFIGURATION \
         --set useLatestContainers=true \
         --set onvifVideo.enabled=true
     watch kubectl get pods,akric,akrii -o wide

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -37,15 +37,24 @@ kubectl label node $HOSTNAME node-role.kubernetes.io/master= --overwrite=true
     ```sh
     curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     ```
-1. If using MicroK8s, enable Helm.
+1. If using MicroK8s, enable Helm, install crictl, and configure Akri to use MicroK8s' CNI socket.
     ```sh
     kubectl config view --raw >~/.kube/config
     chmod go-rwx ~/.kube/config
     microk8s enable helm3
+
+    # Note that we aren't aware of any version restrictions
+    VERSION="v1.17.0"
+    curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
+    sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+    rm -f crictl-$VERSION-linux-amd64.tar.gz
+
+    export AKRI_HELM_CRICTL_CONFIGURATION="--set agent.host.crictl=/usr/local/bin/crictl --set agent.host.dockerShimSock=/var/snap/microk8s/common/run/containerd.sock"
     ```
-1. If using K3s, point to `kubeconfig` for Helm.
+1. If using K3s, point to `kubeconfig` for Helm and configure Akri to use the K3s embedded crictl
     ```sh
     export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+    export AKRI_HELM_CRICTL_CONFIGURATION="--set agent.host.crictl=/usr/local/bin/crictl --set agent.host.dockerShimSock=/run/k3s/containerd/containerd.sock"
     ```
 1. Install Akri Helm chart and enable the desired Configuration (in this case, ONVIF is enabled). See the [ONVIF Configuration documentation](./onvif-sample.md) to learn how to customize the Configuration. Instructions on deploying the udev Configuration can be found in [this document](./udev-sample.md).
     ```sh

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -37,25 +37,29 @@ kubectl label node $HOSTNAME node-role.kubernetes.io/master= --overwrite=true
     ```sh
     curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
     ```
-1. If using MicroK8s, enable Helm, install crictl, and configure Akri to use MicroK8s' CNI socket.
-    ```sh
-    kubectl config view --raw >~/.kube/config
-    chmod go-rwx ~/.kube/config
-    microk8s enable helm3
+1. Provide runtime-specific configuration
 
-    # Note that we aren't aware of any version restrictions
-    VERSION="v1.17.0"
-    curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
-    sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
-    rm -f crictl-$VERSION-linux-amd64.tar.gz
+    1. If using K3s, point to `kubeconfig` for Helm and configure Akri to use the K3s embedded crictl
+        ```sh
+        export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+        export AKRI_HELM_CRICTL_CONFIGURATION="--set agent.host.crictl=/usr/local/bin/crictl --set agent.host.dockerShimSock=/run/k3s/containerd/containerd.sock"
+        ```
+    1. If using MicroK8s, enable Helm, install crictl, and configure Akri to use MicroK8s' CNI socket.
+        ```sh
+        kubectl config view --raw >~/.kube/config
+        chmod go-rwx ~/.kube/config
+        microk8s enable helm3
 
-    export AKRI_HELM_CRICTL_CONFIGURATION="--set agent.host.crictl=/usr/local/bin/crictl --set agent.host.dockerShimSock=/var/snap/microk8s/common/run/containerd.sock"
-    ```
-1. If using K3s, point to `kubeconfig` for Helm and configure Akri to use the K3s embedded crictl
-    ```sh
-    export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-    export AKRI_HELM_CRICTL_CONFIGURATION="--set agent.host.crictl=/usr/local/bin/crictl --set agent.host.dockerShimSock=/run/k3s/containerd/containerd.sock"
-    ```
+        # Note that we aren't aware of any version restrictions
+        VERSION="v1.17.0"
+        curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-${VERSION}-linux-amd64.tar.gz --output crictl-${VERSION}-linux-amd64.tar.gz
+        sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
+        rm -f crictl-$VERSION-linux-amd64.tar.gz
+
+        export AKRI_HELM_CRICTL_CONFIGURATION="--set agent.host.crictl=/usr/local/bin/crictl --set agent.host.dockerShimSock=/var/snap/microk8s/common/run/containerd.sock"
+        ```
+    1. If using Kubernetes, Helm and crictl do not require additional configuration.
+
 1. Install Akri Helm chart and enable the desired Configuration (in this case, ONVIF is enabled). See the [ONVIF Configuration documentation](./onvif-sample.md) to learn how to customize the Configuration. Instructions on deploying the udev Configuration can be found in [this document](./udev-sample.md).
     ```sh
     helm repo add akri-helm-charts https://deislabs.github.io/akri/


### PR DESCRIPTION
Akri uses the CNI socket and crictl on the host to query some container information.

* Add connection information for K3s' embedded crictl implementation.
* Add connection information for MicroK8s (including crictl installation details)