### PR TITLE
Trigger e2e tests when the test files change, change timeout [SAME VERSION]

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -13,12 +13,16 @@ on:
   push:
     branches: [ main ]
     paths:
+    - test/run-end-to-end.py
+    - test/run-conservation-of-broker-pod.py
+    - test/run-helm-install-delete.py
+    - test/shared_test_code.py
+    - .github/workflows/run-test-cases.yml
     - version.txt
     
 jobs:
   test-cases:
     runs-on: ubuntu-18.04
-    timeout-minutes: 20
 
     strategy:
       fail-fast: false

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -23,6 +23,7 @@ on:
 jobs:
   test-cases:
     runs-on: ubuntu-18.04
+    timeout-minutes: 35
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Renaming the workflow and merging it does not trigger a re-run of the test during the push.  This leads to a 'no status' message in the badge.
