### PR TITLE
docs: Move code of conduct to its own file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,2 @@
-## Code of Conduct
+# Community Code of Conduct
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact opencode@microsoft.com with any additional questions or comments.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+## Code of Conduct
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact opencode@microsoft.com with any additional questions or comments.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,5 +34,5 @@ Most contributions require you to agree to a Contributor License Agreement (CLA)
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
 
-## Code of Conduct	
+## Code of Conduct
 Participation in the Akri community is governed by the [Code of Conduct](../CODE_OF_CONDUCT.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,3 +33,6 @@ To ensure that all product versioning is consistent, our CI builds will execute 
 Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+## Code of Conduct	
+Participation in the Akri community is governed by the [Code of Conduct](../CODE_OF_CONDUCT.md).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,6 +33,3 @@ To ensure that all product versioning is consistent, our CI builds will execute 
 Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
-
-## Code of Conduct
-This project has adopted the Microsoft Open Source Code of Conduct. For more information see the Code of Conduct FAQ or contact opencode@microsoft.com with any additional questions or comments.


### PR DESCRIPTION
Move code of conduct to its own file so it will show up under [Akri's community tab](https://github.com/deislabs/akri/community/).
