### PR TITLE
Remove gstreamer dependencies

### DIFF
--- a/build/setup.sh
+++ b/build/setup.sh
@@ -1,5 +1,5 @@
 
-apt_dependencies="git curl libssl-dev pkg-config libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav libgstrtspserver-1.0-dev libges-1.0-dev libudev-dev libv4l-dev"
+apt_dependencies="git curl libssl-dev pkg-config libudev-dev libv4l-dev"
 
 echo "User: $(whoami)"
 


### PR DESCRIPTION
We have gstreamer dependencies in our build instructions. They were most likely added because they were needed for the end to end demo. However, they are not necessary otherwise. This PR removes them.