### PR TITLE
Run CI builds in Akri context rather than user context [SAME VERSION] [ALLOW INTERMEDIATE BUILDS]

### DIFF
--- a/.github/actions/build-component-multi-arch/action.yml
+++ b/.github/actions/build-component-multi-arch/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: Component prefix used by Makefile
     required: true
   github_event_name:
-    description: Specify the github event name (push, pull_request, release, etc)
+    description: Specify the github event name (push, pull_request_target, release, etc)
     required: true
 runs:
   using: 'node12'

--- a/.github/actions/build-component-per-arch/action.yml
+++ b/.github/actions/build-component-per-arch/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: Specify whether rust is being built
     required: true
   github_event_name:
-    description: Specify the github event name (push, pull_request, release, etc)
+    description: Specify the github event name (push, pull_request_target, release, etc)
     required: true
   github_ref:
     description: Specify the github ref

--- a/.github/actions/build-component-per-arch/main.js
+++ b/.github/actions/build-component-per-arch/main.js
@@ -37,7 +37,7 @@ async function shell_cmd(cmd) {
         if (core.getInput('github_event_name') == 'release') push_containers = 1;
         else if (core.getInput('github_event_name') == 'push' && 
                 core.getInput('github_ref') == 'refs/heads/main') push_containers = 1;
-        else if (core.getInput('github_event_name') == 'pull_request' && 
+        else if (core.getInput('github_event_name') == 'pull_request_target' && 
                 core.getInput('github_event_action') == 'closed' && 
                 core.getInput('github_ref') == 'refs/heads/main' && 
                 core.getInput('github_merged') == 'true') push_containers = 1;

--- a/.github/actions/build-intermediate/action.yml
+++ b/.github/actions/build-intermediate/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: Platform to build (amd64|arm64|arm32)
     required: true
   github_event_name:
-    description: Specify the github event name (push, pull_request, release, etc)
+    description: Specify the github event name (push, pull_request_target, release, etc)
     required: true
   github_ref:
     description: Specify the github ref

--- a/.github/actions/build-intermediate/main.js
+++ b/.github/actions/build-intermediate/main.js
@@ -32,7 +32,7 @@ async function shell_cmd(cmd) {
         if (core.getInput('github_event_name') == 'release') push_containers = 1;
         else if (core.getInput('github_event_name') == 'push' && 
                 core.getInput('github_ref') == 'refs/heads/main') push_containers = 1;
-        else if (core.getInput('github_event_name') == 'pull_request' && 
+        else if (core.getInput('github_event_name') == 'pull_request_target' && 
                 core.getInput('github_event_action') == 'closed' && 
                 core.getInput('github_ref') == 'refs/heads/main' && 
                 core.getInput('github_merged') == 'true') push_containers = 1;

--- a/.github/workflows/build-agent-container.yml
+++ b/.github/workflows/build-agent-container.yml
@@ -15,7 +15,6 @@ on:
     - build/akri-containers.mk
     - Makefile
   pull_request_target:
-    branches: [ main ]
     paths:
     - .github/actions/build-component-per-arch/**
     - .github/actions/build-component-multi-arch/**

--- a/.github/workflows/build-agent-container.yml
+++ b/.github/workflows/build-agent-container.yml
@@ -14,7 +14,7 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - .github/actions/build-component-per-arch/**
@@ -77,7 +77,7 @@ jobs:
         build_rust: "1"
 
   multi-arch:
-    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
     needs: per-arch
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/build-controller-container.yml
+++ b/.github/workflows/build-controller-container.yml
@@ -15,7 +15,6 @@ on:
     - build/akri-containers.mk
     - Makefile
   pull_request_target:
-    branches: [ main ]
     paths:
     - .github/actions/build-component-per-arch/**
     - .github/actions/build-component-multi-arch/**

--- a/.github/workflows/build-controller-container.yml
+++ b/.github/workflows/build-controller-container.yml
@@ -14,7 +14,7 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - .github/actions/build-component-per-arch/**
@@ -76,7 +76,7 @@ jobs:
         build_rust: "1"
 
   multi-arch:
-    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
     needs: per-arch
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/build-onvif-video-broker-container.yml
+++ b/.github/workflows/build-onvif-video-broker-container.yml
@@ -12,7 +12,7 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - .github/actions/build-component-per-arch/**
@@ -73,7 +73,7 @@ jobs:
         build_rust: "0"
 
   multi-arch:
-    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
     needs: per-arch
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/build-onvif-video-broker-container.yml
+++ b/.github/workflows/build-onvif-video-broker-container.yml
@@ -13,7 +13,6 @@ on:
     - build/akri-containers.mk
     - Makefile
   pull_request_target:
-    branches: [ main ]
     paths:
     - .github/actions/build-component-per-arch/**
     - .github/actions/build-component-multi-arch/**

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -9,7 +9,7 @@ on:
     - build/containers/intermediate/Dockerfile.opencvsharp-build
     - build/intermediate-containers.mk
     - Makefile
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - .github/actions/build-intermediate/**
@@ -51,7 +51,7 @@ jobs:
 
     # Only run build version change check if PR title and Merge commit message do NOT contain "[SAME VERSION]"
     - if: >-
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         !contains(github.event.pull_request.title, '[SAME VERSION]') &&
         !contains(github.event.commits[0].message, '[SAME VERSION]')
       name: Ensure that ${{ env.AKRI_COMPONENT }} version has changed

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -10,7 +10,6 @@ on:
     - build/intermediate-containers.mk
     - Makefile
   pull_request_target:
-    branches: [ main ]
     paths:
     - .github/actions/build-intermediate/**
     - .github/workflows/build-opencv-base-container.yml

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -9,7 +9,7 @@ on:
     - build/containers/intermediate/Dockerfile.rust-crossbuild-*
     - build/intermediate-containers.mk
     - Makefile
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - .github/actions/build-intermediate/**
@@ -51,7 +51,7 @@ jobs:
 
     # Only run build version change check if PR title and Merge commit message do NOT contain "[SAME VERSION]"
     - if: >-
-        github.event_name == 'pull_request' &&
+        github.event_name == 'pull_request_target' &&
         !contains(github.event.pull_request.title, '[SAME VERSION]') &&
         !contains(github.event.commits[0].message, '[SAME VERSION]')
       name: Ensure that ${{ env.AKRI_COMPONENT }} version has changed

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -10,7 +10,6 @@ on:
     - build/intermediate-containers.mk
     - Makefile
   pull_request_target:
-    branches: [ main ]
     paths:
     - .github/actions/build-intermediate/**
     - .github/workflows/build-rust-crossbuild-container.yml

--- a/.github/workflows/build-udev-video-broker-container.yml
+++ b/.github/workflows/build-udev-video-broker-container.yml
@@ -15,7 +15,6 @@ on:
     - build/akri-containers.mk
     - Makefile
   pull_request_target:
-    branches: [ main ]
     paths:
     - .github/actions/build-component-per-arch/**
     - .github/actions/build-component-multi-arch/**

--- a/.github/workflows/build-udev-video-broker-container.yml
+++ b/.github/workflows/build-udev-video-broker-container.yml
@@ -14,7 +14,7 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - .github/actions/build-component-per-arch/**
@@ -77,7 +77,7 @@ jobs:
         build_rust: "1"
 
   multi-arch:
-    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
     needs: per-arch
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/build-video-streaming-app-container.yml
+++ b/.github/workflows/build-video-streaming-app-container.yml
@@ -12,7 +12,7 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - .github/actions/build-component-per-arch/**
@@ -73,7 +73,7 @@ jobs:
         build_rust: "0"
 
   multi-arch:
-    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
     needs: per-arch
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/build-video-streaming-app-container.yml
+++ b/.github/workflows/build-video-streaming-app-container.yml
@@ -13,7 +13,6 @@ on:
     - build/akri-containers.mk
     - Makefile
   pull_request_target:
-    branches: [ main ]
     paths:
     - .github/actions/build-component-per-arch/**
     - .github/actions/build-component-multi-arch/**

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -10,7 +10,6 @@ on:
     - '**/Cargo.lock'
     - build/setup.sh
   pull_request_target:
-    branches: [ main ]
     paths:
     - .github/workflows/check-rust.yml
     - '**.rs'

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -9,7 +9,7 @@ on:
     - '**/Cargo.toml'
     - '**/Cargo.lock'
     - build/setup.sh
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - .github/workflows/check-rust.yml

--- a/.github/workflows/check-versioning.yml
+++ b/.github/workflows/check-versioning.yml
@@ -10,7 +10,6 @@ on:
       - .vscode/**
       - docs/**
   pull_request_target:
-    branches: [ main ]
     paths-ignore:
       - '.gitignore'
       - 'LICENSE'

--- a/.github/workflows/check-versioning.yml
+++ b/.github/workflows/check-versioning.yml
@@ -9,7 +9,7 @@ on:
       - '**.md'
       - .vscode/**
       - docs/**
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths-ignore:
       - '.gitignore'
@@ -35,11 +35,11 @@ jobs:
 
     # Only run version check for PRs.  If PR title does NOT contain "[SAME VERSION]", then ensure that
     # version.txt is different from what is in main.
-    - if: github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[SAME VERSION]') == false
+    - if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.title, '[SAME VERSION]') == false
       name: Run version check
       run: ./version.sh -c
     # If PR title does contain "[SAME VERSION]", then do not check that version.txt is different from
     # what is in main.
-    - if: github.event_name == 'pull_request' && contains(github.event.pull_request.title, '[SAME VERSION]') == true
+    - if: github.event_name == 'pull_request_target' && contains(github.event.pull_request.title, '[SAME VERSION]') == true
       name: Run version check
       run: ./version.sh -c -s

--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -8,7 +8,6 @@ on:
     - deployment/**
     - version.txt
   pull_request_target:
-    branches: [ main ]
     paths:
     - .github/workflows/run-helm.yml
     - deployment/**

--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -7,7 +7,7 @@ on:
     - .github/workflows/run-helm.yml
     - deployment/**
     - version.txt
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - .github/workflows/run-helm.yml
@@ -43,38 +43,38 @@ jobs:
         run: helm inspect all $(find /tmp/helm/repo -name "akri-*.tgz")
 
       - name: Upload new helm package as artifact
-        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
         uses: actions/upload-artifact@v2
         with:
           name: charts
           path: /tmp/helm/repo
 
       - name: Checkout gh-pages
-        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
         uses: actions/checkout@v2
         with:
           ref: gh-pages
 
       - name: Get new chart from artifact path
-        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
         shell: bash
         run: |
           mv /tmp/helm/repo/* .
           find .
 
       - name: Create new merged helm chart index
-        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
         run: helm repo index --url https://deislabs.github.io/akri --merge index.yaml .
 
       - name: Upload new merged helm chart index as artifact
-        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
         uses: actions/upload-artifact@v2
         with:
           name: index
           path: index.yaml
   
       - name: Push gh-pages
-        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+        if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
         shell: bash
         run: |
           git config user.name "${GITHUB_ACTOR}"

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -9,7 +9,6 @@ on:
     - '**/Cargo.toml'
     - build/setup.sh
   pull_request_target:
-    branches: [ main ]
     paths:
     - .github/workflows/check-rust.yml
     - '**.rs'

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -8,7 +8,7 @@ on:
     - '**.rs'
     - '**/Cargo.toml'
     - build/setup.sh
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - .github/workflows/check-rust.yml

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -2,7 +2,7 @@ name: Run End-to-End Scenario
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
     - test/run-end-to-end.py

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -3,7 +3,6 @@ name: Run End-to-End Scenario
 on:
   workflow_dispatch:
   pull_request_target:
-    branches: [ main ]
     paths:
     - test/run-end-to-end.py
     - test/run-conservation-of-broker-pod.py


### PR DESCRIPTION
In order to allow access to secrets from external PRs, use pull_request_target rather than pull_request per https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/.