### PR TITLE
Helm 3 is  bundled w/ MicroK8s

### DIFF
--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -54,13 +54,14 @@ carry out one or the other, then continue on with the rest of the steps.
     ```sh
     microk8s status --wait-ready
     ```
-1. If you don't have an existing `kubectl` installation, add a kubectl alias. If you do not want to set an alias, add `microk8s` in front of all kubectl commands.
-    ```sh
-    alias kubectl='microk8s kubectl'
-    ```
 1. Enable CloudDNS, Helm and RBAC for MicroK8s.
     ```sh
     microk8s enable dns helm3 rbac
+    ```
+1. If you don't have an existing `kubectl` and `helm` installations, add aliases. If you do not want to set an alias, add `microk8s` in front of all `kubectl` and `helm` commands.
+    ```sh
+    alias kubectl='microk8s kubectl'
+    alias helm='microk8s helm3'
     ```
 1. Enable privileged pods and restart microk8s.
     ```sh

--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -58,11 +58,6 @@ carry out one or the other, then continue on with the rest of the steps.
     ```sh
     alias kubectl='microk8s kubectl'
     ```
-1. Install Helm.
-    ```sh
-    sudo apt install -y curl
-    curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-    ```
 1. Enable Helm for MicroK8s.
     ```sh
     kubectl config view --raw >~/.kube/config

--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -58,18 +58,10 @@ carry out one or the other, then continue on with the rest of the steps.
     ```sh
     alias kubectl='microk8s kubectl'
     ```
-1. Enable Helm for MicroK8s.
+1. Enable CloudDNS, Helm and RBAC for MicroK8s.
     ```sh
     kubectl config view --raw >~/.kube/config
-    microk8s enable helm3
-    ```
-1. Enable dns.
-    ```sh
-    microk8s enable dns
-    ```
-1. Optionally enable rbac.
-    ```sh
-    microk8s enable rbac
+    microk8s enable dns helm3 rbac
     ```
 1. Enable privileged pods and restart microk8s.
     ```sh

--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -60,7 +60,6 @@ carry out one or the other, then continue on with the rest of the steps.
     ```
 1. Enable CloudDNS, Helm and RBAC for MicroK8s.
     ```sh
-    kubectl config view --raw >~/.kube/config
     microk8s enable dns helm3 rbac
     ```
 1. Enable privileged pods and restart microk8s.


### PR DESCRIPTION
Fixes #44 (@kate-goldenring) 

Helm 3 is bundled w/ MicroK8s and does not need to be installed, just enabled.

I'm unclear why the `kubectl config view --raw >~/.kube/config` is needed prior to `microk8s enable helm3`; it's possible redundant too.