### PR TITLE
Reduce the number of PRs that trigger a version check [SAME VERSION]

### DIFF
--- a/.github/workflows/check-versioning.yml
+++ b/.github/workflows/check-versioning.yml
@@ -9,6 +9,8 @@ on:
       - '**.md'
       - .vscode/**
       - docs/**
+      - Notice.txt
+      - scripts/**
   pull_request_target:
     branches: [ main ]
     paths-ignore:
@@ -17,6 +19,8 @@ on:
       - '**.md'
       - .vscode/**
       - docs/**
+      - Notice.txt
+      - scripts/**
   release:
     types:
       - published

--- a/.github/workflows/check-versioning.yml
+++ b/.github/workflows/check-versioning.yml
@@ -8,13 +8,13 @@ on:
       - 'LICENSE'
       - '**.md'
       - Notice.txt
-      - .github/workflows/check-versioning.yml
-      - .github/workflows/check-rust.yml
-      - .github/workflows/run-tarpaulin.yml
-      - .github/workflows/run-test-cases.yml
-      - .github/ISSUE_TEMPLATE/**
-      - .github/CODEOWNERS
-      - .vscode/**
+      - '.github/workflows/check-versioning.yml'
+      - '.github/workflows/check-rust.yml'
+      - '.github/workflows/run-tarpaulin.yml'
+      - '.github/workflows/run-test-cases.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/CODEOWNERS'
+      - '.vscode/**'
       - docs/**
       - scripts/**
       - tests/**
@@ -25,13 +25,13 @@ on:
       - 'LICENSE'
       - '**.md'
       - Notice.txt
-      - .github/workflows/check-versioning.yml
-      - .github/workflows/check-rust.yml
-      - .github/workflows/run-tarpaulin.yml
-      - .github/workflows/run-test-cases.yml
-      - .github/ISSUE_TEMPLATE/**
-      - .github/CODEOWNERS
-      - .vscode/**
+      - '.github/workflows/check-versioning.yml'
+      - '.github/workflows/check-rust.yml'
+      - '.github/workflows/run-tarpaulin.yml'
+      - '.github/workflows/run-test-cases.yml'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/CODEOWNERS'
+      - '.vscode/**'
       - docs/**
       - scripts/**
       - tests/**

--- a/.github/workflows/check-versioning.yml
+++ b/.github/workflows/check-versioning.yml
@@ -7,20 +7,34 @@ on:
       - '.gitignore'
       - 'LICENSE'
       - '**.md'
+      - Notice.txt
+      - .github/workflows/check-versioning.yml
+      - .github/workflows/check-rust.yml
+      - .github/workflows/run-tarpaulin.yml
+      - .github/workflows/run-test-cases.yml
+      - .github/ISSUE_TEMPLATE/**
+      - .github/CODEOWNERS
       - .vscode/**
       - docs/**
-      - Notice.txt
       - scripts/**
+      - tests/**
   pull_request_target:
     branches: [ main ]
     paths-ignore:
       - '.gitignore'
       - 'LICENSE'
       - '**.md'
+      - Notice.txt
+      - .github/workflows/check-versioning.yml
+      - .github/workflows/check-rust.yml
+      - .github/workflows/run-tarpaulin.yml
+      - .github/workflows/run-test-cases.yml
+      - .github/ISSUE_TEMPLATE/**
+      - .github/CODEOWNERS
       - .vscode/**
       - docs/**
-      - Notice.txt
       - scripts/**
+      - tests/**
   release:
     types:
       - published


### PR DESCRIPTION
**What this PR does / why we need it**:
Too many PRs require [SAME VERSION] tag to clear the version check.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)