### PR TITLE
[Extensibility] Compilation errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,12 @@
 # Ignore everything
 **
 
+# Nessie broker
+# The source code and the shared project need to be
+# available to the container build
+!samples/brokers/nessie
+!shared/
+
 # ONVIF broker is built using a `docker build` command, so
 # the source code needs to be available to the DotNet container
 # build

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,12 +2,6 @@
 # Ignore everything
 **
 
-# Nessie broker
-# The source code and the shared project need to be
-# available to the container build
-!samples/brokers/nessie
-!shared/
-
 # ONVIF broker is built using a `docker build` command, so
 # the source code needs to be available to the DotNet container
 # build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@
 h2 = { git = "https://github.com/kate-goldenring/h2", branch = "master"}
 
 [workspace]
-members = ["shared", "controller", "agent", "samples/brokers/udev-video-broker", "samples/brokers/nessie" ]
+members = ["shared", "controller", "agent", "samples/brokers/udev-video-broker"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@
 h2 = { git = "https://github.com/kate-goldenring/h2", branch = "master"}
 
 [workspace]
-members = ["shared", "controller", "agent", "samples/brokers/udev-video-broker"]
+members = ["shared", "controller", "agent", "samples/brokers/udev-video-broker", "samples/brokers/nessie" ]

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -454,7 +454,7 @@ We have provided makefiles for building and pushing containers for the various c
 PREFIX=ghcr.io/<your-github-alias> BUILD_AMD64=1 BUILD_ARM32=0 BUILD_ARM64=0 make akri-agent
 PREFIX=ghcr.io/<your-github-alias> BUILD_AMD64=1 BUILD_ARM32=0 BUILD_ARM64=0 make akri-controller
 ```
-Next, you must [generate a new Akri chart](./development#helm-template). You can now [install Akri with the newly built containers](./development#install-akri-with-newly-built-containers), setting the appropriate image address for the Agent and Controller pods in your personal container registry. 
+Next, you must [generate a new Akri chart](./development.md#helm-template). You can now [install Akri with the newly built containers](./development.md#install-akri-with-newly-built-containers), setting the appropriate image address for the Agent and Controller pods in your personal container registry. 
 
 Finally, you can apply your Nessie Configuration and watch as broker pods are created:
 ```sh

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -65,9 +65,9 @@ impl DiscoveryHandler for NessieDiscoveryHandler {
         if let Ok(_body) = hyper::Client::new().get(url).compat().await {
             // If the Nessie URL can be accessed, we will return a DiscoveryResult
             // instance
-            let props = HashMap::new();
+            let props: HashMap<String, String> = HashMap::new();
             props.insert(
-                "nessie_url",
+                "nessie_url".to_string(),
                 self.discovery_handler_config.nessie_url.clone(),
             );
             results.push(DiscoveryResult::new(

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -71,7 +71,7 @@ impl DiscoveryHandler for NessieDiscoveryHandler {
                 self.discovery_handler_config.nessie_url.clone(),
             );
             results.push(DiscoveryResult::new(
-                self.discovery_handler_config.nessie_url,
+                &self.discovery_handler_config.nessie_url,
                 props,
                 true,
             ));

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -38,6 +38,7 @@ use super::super::{DiscoveryHandler, DiscoveryResult};
 use async_trait::async_trait;
 use failure::Error;
 use akri_shared::akri::configuration::NessieDiscoveryHandlerConfig;
+use std::collections::HashMap;
 
 pub struct NessieDiscoveryHandler {
     discovery_handler_config: NessieDiscoveryHandlerConfig,

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -236,6 +236,8 @@ fn main() {
 }
 ```
 
+This build file will compile `nessie.proto` into a rust source file `samples/brokers/nessie/src/util/nessie.rs`.
+
 Next, we need to include the gRPC generated code in by adding a reference to `nessie` in `samples/brokers/nessie/src/util/mod.rs`:
 
 ```rust
@@ -244,7 +246,7 @@ pub mod nessie;
 
 With the gRPC implementation created, we can now start utilizing it.
 
-First, we need to leverage the generated gRPC code by creating `samples/brokers/nessie/src/util/nessie.rs`:
+First, we need to leverage the generated gRPC code by creating `samples/brokers/nessie/src/util/nessie_service.rs`:
 
 ```rust
 use super::{

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -394,6 +394,7 @@ To build the Nessie container, we need to create a Dockerfile
 FROM amd64/rust:1.41 as build
 RUN apt-get update && apt-get install -y --no-install-recommends \
       g++ ca-certificates curl libssl-dev pkg-config
+RUN rustup component add rustfmt --toolchain 1.41.1-x86_64-unknown-linux-gnu
 
 WORKDIR /nessie
 RUN echo '[workspace]' > ./Cargo.toml && \
@@ -405,12 +406,12 @@ RUN cargo build
 FROM amd64/debian:buster-slim
 RUN apt-get update && apt-get install -y --no-install-recommends libssl-dev openssl && \
       apt-get clean
-COPY --from=build ./target/debug/nessie /nessie
+COPY --from=build /nessie/target/debug/nessie /nessie
 
 # Expose port used by broker service
 EXPOSE 8083
 
-CMD ["./nessie"]
+ENTRYPOINT ["/nessie"]
 ```
 
 ### Create a new Configuration

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -109,7 +109,7 @@ The first step is to create a DiscoveryHandler configuration struct. This struct
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct NessieDiscoveryHandlerConfig {
-    nessie_url: String
+    pub nessie_url: String
 }
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

I'm encountering some issues building Nessie and suspect the majority are my noob errors.

However, I suspect `nessie_url` should be (a) public field

**Special notes for your reviewer**:

```console
error[E0616]: field `nessie_url` of struct `akri_shared::akri::configuration::NessieDiscoveryHandlerConfig` is private
  --> agent/src/protocols/nessie/discovery_handler.rs:24:14
   |
24 |             .nessie_url
   |              ^^^^^^^^^^ private field

error[E0061]: this function takes 1 argument but 0 arguments were supplied
  --> agent/src/protocols/nessie/discovery_handler.rs:27:28
   |
27 |         if let Ok(_body) = hyper::Client::new().get(url).compat().await {
   |                            ^^^^^^^^^^^^^^^^^^-- supplied 0 arguments
   |                            |
   |                            expected 1 argument

error[E0599]: no method named `compat` found for struct `hyper::client::FutureResponse` in the current scope
  --> agent/src/protocols/nessie/discovery_handler.rs:27:58
   |
27 |         if let Ok(_body) = hyper::Client::new().get(url).compat().await {
   |                                                          ^^^^^^ method not found in `hyper::client::FutureResponse`

error[E0616]: field `nessie_url` of struct `akri_shared::akri::configuration::NessieDiscoveryHandlerConfig` is private
  --> agent/src/protocols/nessie/discovery_handler.rs:31:47
   |
31 |                 self.discovery_handler_config.nessie_url.clone(),
   |                                               ^^^^^^^^^^ private field

error[E0616]: field `nessie_url` of struct `akri_shared::akri::configuration::NessieDiscoveryHandlerConfig` is private
  --> agent/src/protocols/nessie/discovery_handler.rs:34:48
   |
34 |                 &self.discovery_handler_config.nessie_url,
   |                                                ^^^^^^^^^^ private field
```

**If applicable**:
- [X] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)