### PR TITLE
Fix: gh-pages push needs to pick up akri and akri-dev [SAME VERSION]

### DIFF
--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -113,13 +113,21 @@ jobs:
           name: index
           path: index.yaml
   
+      - name: Create push with new akri chart for gh-pages
+        if: (github.event_name == 'release')
+        shell: bash
+        run: git add akri-$(cat version.txt).tgz
+      - name: Create push with new akri-dev chart for gh-pages
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+        shell: bash
+        run: git add akri-dev-$(cat version.txt).tgz
+
       - name: Push gh-pages
         if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
         shell: bash
         run: |
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git add akri-$(cat version.txt).tgz
           git add index.yaml
           git status
           echo "Update Helm Repo for version $(cat version.txt)" | git commit --file -


### PR DESCRIPTION
**What this PR does / why we need it**:
Previous introduction of dev and release Helm charts failed to add akri-dev-<VERSION>.tgz to gh-pages.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)