### PR TITLE
E2E tests should validate release and dev Helm charts [SAME VERSION]

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -27,6 +27,9 @@ on:
     - test/shared_test_code.py
     - .github/workflows/run-test-cases.yml
     - version.txt
+  release:
+    types:
+      - published
     
 jobs:
   test-cases:
@@ -145,17 +148,35 @@ jobs:
 
     - name: Add Akri Helm Chart
       run: helm repo add akri-helm-charts https://deislabs.github.io/akri/
-    - if: github.event_name == 'push'
+    
+    # When event_name==release, the Helm chart is named 'akri'
+    - if: github.event_name == 'release'
+      name: Pull akri helm chart when event_name == release
+      run: echo akri > /tmp/chart_name.txt
+    # When event_name!=release, the Helm chart is named 'akri-dev'
+    - if: github.event_name != 'release'
+      name: Pull akri-dev helm chart when event_name != release
+      run: echo akri-dev > /tmp/chart_name.txt
+
+    # For push and release, we need to wait for the Helm chart and
+    # associated containers to build.
+    - if: github.event_name == 'push' || github.event_name == 'release'
       name: Set sleep duration before running script to 1500
       run: echo 1500 > /tmp/sleep_duration.txt
-    - if: github.event_name != 'push'
+
+    # For pull_request and pull_request_target, only main's version.txt
+    # has a Helm chart (the version in the PR does not).  Use origin/main.
+    - if: startsWith(github.event_name, 'pull_request')
       name: Use main version for non-push
       run: |
         git fetch origin main
         git show origin/main:version.txt > /tmp/version_to_test.txt
-    - if: github.event_name == 'push'
+    # For non-PR (i.e. push, release, manual), version.txt is corresponds
+    # to an existing Helm chart.
+    - if: (!(startsWith(github.event_name, 'pull_request')))
       name: Use current version for push
       run: cat version.txt > /tmp/version_to_test.txt
+
     - name: Execute test script ${{ matrix.test-file }}
       run: python ${{ matrix.test-file }}
     - name: Upload Agent log as artifact

--- a/test/run-conservation-of-broker-pod.py
+++ b/test/run-conservation-of-broker-pod.py
@@ -26,9 +26,11 @@ def main():
     print("Testing major version: {}".format(shared_test_code.major_version))
 
     print("Installing Akri Helm chart: {}".format(test_version))
+    helm_chart_name = shared_test_code.get_helm_chart_name()
+    print("Get Akri Helm chart: {}".format(helm_chart_name))
     cri_args = shared_test_code.get_cri_args()
     print("Providing Akri Helm chart with CRI args: {}".format(cri_args))
-    helm_install_command = "helm install akri akri-helm-charts/akri --version {} --set debugEcho.enabled=true --set debugEcho.name={} --set debugEcho.shared=false --set agent.allowDebugEcho=true {}".format(test_version, shared_test_code.DEBUG_ECHO_NAME, cri_args)
+    helm_install_command = "helm install akri akri-helm-charts/{} --version {} --set debugEcho.enabled=true --set debugEcho.name={} --set debugEcho.shared=false --set agent.allowDebugEcho=true {}".format(helm_chart_name, test_version, shared_test_code.DEBUG_ECHO_NAME, cri_args)
     print("Helm command: {}".format(helm_install_command))
     os.system(helm_install_command)
     

--- a/test/run-end-to-end.py
+++ b/test/run-end-to-end.py
@@ -26,9 +26,11 @@ def main():
     print("Testing major version: {}".format(shared_test_code.major_version))
 
     print("Installing Akri Helm chart: {}".format(test_version))
+    helm_chart_name = shared_test_code.get_helm_chart_name()
+    print("Get Akri Helm chart: {}".format(helm_chart_name))
     cri_args = shared_test_code.get_cri_args()
     print("Providing Akri Helm chart with CRI args: {}".format(cri_args))
-    helm_install_command = "helm install akri akri-helm-charts/akri --version {} --set debugEcho.enabled=true --set debugEcho.name={} --set debugEcho.shared=false --set agent.allowDebugEcho=true {}".format(test_version, shared_test_code.DEBUG_ECHO_NAME, cri_args)
+    helm_install_command = "helm install akri akri-helm-charts/{} --version {} --set debugEcho.enabled=true --set debugEcho.name={} --set debugEcho.shared=false --set agent.allowDebugEcho=true {}".format(helm_chart_name, test_version, shared_test_code.DEBUG_ECHO_NAME, cri_args)
     print("Helm command: {}".format(helm_install_command))
     os.system(helm_install_command)
     

--- a/test/run-helm-install-delete.py
+++ b/test/run-helm-install-delete.py
@@ -26,9 +26,11 @@ def main():
     print("Testing major version: {}".format(shared_test_code.major_version))
 
     print("Installing Akri Helm chart: {}".format(test_version))
+    helm_chart_name = shared_test_code.get_helm_chart_name()
+    print("Get Akri Helm chart: {}".format(helm_chart_name))
     cri_args = shared_test_code.get_cri_args()
     print("Providing Akri Helm chart with CRI args: {}".format(cri_args))
-    helm_install_command = "helm install akri akri-helm-charts/akri --version {} --set debugEcho.enabled=true --set debugEcho.name={} --set debugEcho.shared=false --set agent.allowDebugEcho=true {}".format(test_version, shared_test_code.DEBUG_ECHO_NAME, cri_args)
+    helm_install_command = "helm install akri akri-helm-charts/{} --version {} --set debugEcho.enabled=true --set debugEcho.name={} --set debugEcho.shared=false --set agent.allowDebugEcho=true {}".format(helm_chart_name, test_version, shared_test_code.DEBUG_ECHO_NAME, cri_args)
     print("Helm command: {}".format(helm_install_command))
     os.system(helm_install_command)
     

--- a/test/shared_test_code.py
+++ b/test/shared_test_code.py
@@ -16,6 +16,7 @@ KUBE_CONFIG_PATH_FILE = "/tmp/kubeconfig_path_to_test.txt"
 RUNTIME_COMMAND_FILE = "/tmp/runtime_cmd_to_test.txt"
 HELM_CRI_ARGS_FILE = "/tmp/cri_args_to_test.txt"
 VERSION_FILE = "/tmp/version_to_test.txt"
+HELM_CHART_NAME_FILE = "/tmp/chart_name.txt"
 SLEEP_DURATION_FILE = "/tmp/sleep_duration.txt"
 SLEEP_INTERVAL = 20
 
@@ -53,6 +54,10 @@ def get_kubectl_command():
 def get_cri_args():
     # Get CRI args for Akri Helm
     return open(HELM_CRI_ARGS_FILE, "r").readline().rstrip()
+
+def get_helm_chart_name():
+    # Get Helm chart name (akri, akri-dev)
+    return open(HELM_CHART_NAME_FILE, "r").readline().rstrip()
 
 def get_test_version():
     # Get version of akri to test


### PR DESCRIPTION
**What this PR does / why we need it**:
Separate Helm charts are now created both for each PR merge (akri-dev) and release (akri).  The E2E tests should run against the appropriate chart.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)