### PR TITLE
Update end-to-end-demo.md

### DIFF
--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -88,7 +88,7 @@ carry out one or the other, then continue on with the rest of the steps.
     ```
 1. Install Gstreamer main packages
     ```sh
-    sudo apt-get install -y libgstreamer1.0-0 gstreamer1.0-dev gstreamer1.0-tools \
+    sudo apt-get install -y libgstreamer1.0-0 libgstreamer1.0-dev gstreamer1.0-tools \
                             gstreamer1.0-doc gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
                             gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly \
                             gstreamer1.0-libav gstreamer1.0-doc gstreamer1.0-tools \


### PR DESCRIPTION
Hi there,

I try to replicate this demo: apt (on Ubuntu 20.04) doesn't find gstreamer1.0-dev but rather finds libgstreamer1.0-dev.  So, am I right to correct to libgstreamer in this page?

Didier