### PR TITLE
Update end-to-end-demo.md

### DIFF
--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -61,7 +61,7 @@ carry out one or the other, then continue on with the rest of the steps.
     ```
 1. Enable privileged pods and restart microk8s.
     ```sh
-    echo "--allow-privileged=true" >> /var/snap/microk8s/current/args/kube-apiserver
+    echo "--allow-privileged=true" >> /snap/microk8s/current/default-args/kube-apiserver
     microk8s.stop
     microk8s.start
     ```


### PR DESCRIPTION
Hi there,

/var/snap/etc.. no longer exists in recent version : it is now /snap/ect...   Also args/kube-apiserver not present on Ubuntu 20.04 : is default-args/kube-apiserver the proper replacement?

Didier