### PR TITLE
Add information about configmaps to deployment strategies proposal [SAME VERSION]

### DIFF
--- a/docs/proposals/broker-deployment-strategies.md
+++ b/docs/proposals/broker-deployment-strategies.md
@@ -66,8 +66,9 @@ several possibilities for supporting **dynamic instance pooling**:
 1. The Controller could create a ConfigMap with metadata about instances that are assigned to a specific broker and 
    mount this ConfigMap into the broker as a volume. When the Controller wants to change the assignment of instances
    to brokers, it just needs to update the ConfigMaps. The changes are propagated into the broker mounted volumes and 
-   brokers can adjust accordingly (see for reference: 
-   https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically)
+   brokers can adjust accordingly (see [Kubernetes 
+   docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically) 
+   for reference).
 
 A more immediate solution would be to implement **static instance pooling**. The `instance-pooling` value would define
 the exact number of Instance that must be available for a broker to be scheduled. If `instance-pooling` is set to 3 and

--- a/docs/proposals/broker-deployment-strategies.md
+++ b/docs/proposals/broker-deployment-strategies.md
@@ -63,6 +63,11 @@ several possibilities for supporting **dynamic instance pooling**:
    connection information to the main broker container. This would reduce the amount of changes a user would have to
    make to their broker; however, they would have to implement this separate container. Or maybe this could be
    generalized.
+1. The Controller could create a ConfigMap with metadata about instances that are assigned to a specific broker and 
+   mount this ConfigMap into the broker as a volume. When the Controller wants to change the assignment of instances
+   to brokers, it just needs to update the ConfigMaps. The changes are propagated into the broker mounted volumes and 
+   brokers can adjust accordingly (see for reference: 
+   https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically)
 
 A more immediate solution would be to implement **static instance pooling**. The `instance-pooling` value would define
 the exact number of Instance that must be available for a broker to be scheduled. If `instance-pooling` is set to 3 and


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an idea how to leverage configmaps for storing instance metadata such that controller could update it without restarting brokers.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)