### PR TITLE
Use specific Helm version for build [SAME VERSION]

### DIFF
--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -50,6 +50,8 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: azure/setup-helm@v1
+        with:
+          version: "v3.4.0"
 
       # We should generate two sets of akri charts.
       # One for our releases (akri) and one for our merged PRs (akri-dev).  'akri' should only be created for


### PR DESCRIPTION
**What this PR does / why we need it**:
Without specifying the version of Helm, our builds can break unexpectedly.  Specify v3.4.0 for now.  We can intentionally change this later as desired.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)