### PR TITLE
Helm workflow should lint using latest Helm version (as warning, not as failure) [SAME VERSION]

### DIFF
--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: azure/setup-helm@v1
 
       - name: Lint helm chart
-        run: helm lint deployment/helm
+        run: helm lint deployment/helme && echo "lint finished successfully" || echo "lint found issues"
 
 
   helm:

--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: azure/setup-helm@v1
 
       - name: Lint helm chart
-        run: helm lint deployment/helm && echo "lint finished successfully" || echo "lint found issues"
+        run: helm lint deployment/helm && echo "lint finished successfully" || echo ::warning::"lint found issues"
 
 
   helm:

--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: azure/setup-helm@v1
 
       - name: Lint helm chart
-        run: helm lint deployment/helme && echo "lint finished successfully" || echo "lint found issues"
+        run: helm lint deployment/helm && echo "lint finished successfully" || echo "lint found issues"
 
 
   helm:

--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -27,6 +27,33 @@ env:
   helm_version: "3.2.1"
 
 jobs:
+  lint-with-current-helm:
+    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
+    if: >-
+      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
+      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout the merged commit from PR and base branch
+        uses: actions/checkout@v2
+        if: github.event_name == 'pull_request_target'
+        with:
+          # pull_request_target is run in the context of the base repository
+          # of the pull request, so the default ref is master branch and
+          # ref should be manually set to the head of the PR
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+
+      - name: Checkout the head commit of the branch
+        if: ${{ github.event_name != 'pull_request_target' }}
+        uses: actions/checkout@v2
+
+      - uses: azure/setup-helm@v1
+
+      - name: Lint helm chart
+        run: helm lint deployment/helm
+
+
   helm:
     # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
     if: >-


### PR DESCRIPTION
**What this PR does / why we need it**:
When Helm releases a new version, the linting capabilities change.  We should leverage any new lints as a way of seeing new potential issues in our Helm chart.  At the same time, these shouldn't cause a break in our CI builds.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)