### PR TITLE
Fix streaming reference

### DIFF
--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -133,7 +133,7 @@ carry out one or the other (or adopt to your distribution), then continue on wit
     ```sh 
     kubectl get akrii -o yaml
     ```
-1. Deploy the steaming web application and watch a pod spin up for the app.
+1. Deploy the streaming web application and watch a pod spin up for the app.
     ```sh
     kubectl apply -f https://raw.githubusercontent.com/deislabs/akri/main/deployment/samples/akri-video-streaming-app.yaml
     ```

--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -29,10 +29,12 @@ In this guide, you will deploy Akri end-to-end, all the way from discovering loc
     ```
     If this generates an error, be sure that there are no existing video streams targeting /dev/video2 (you can query with commands like this: `ps -aux | grep gst-launch-1.0 | grep "/dev/video2"`).
 
+## Set up a cluster
+
 **Note:** Feel free to deploy on any Kubernetes distribution. Here, find instructions for K3s and MicroK8s. Select and
 carry out one or the other (or adopt to your distribution), then continue on with the rest of the steps. 
 
-## Option 1: Set up single node cluster using K3s
+### Option 1: Set up single node cluster using K3s
 1. Acquire a Linux distro that is supported by K3s, these steps work for Ubuntu.
 1. Install [K3s](https://k3s.io/).
     ```sh
@@ -62,7 +64,7 @@ carry out one or the other (or adopt to your distribution), then continue on wit
     export AKRI_HELM_CRICTL_CONFIGURATION="--set agent.host.crictl=/usr/local/bin/crictl --set agent.host.dockerShimSock=/run/k3s/containerd/containerd.sock"
     ```
 
-## Option 2: Set up single node cluster using MicroK8s
+### Option 2: Set up single node cluster using MicroK8s
 1. Acquire an Ubuntu 20.04 LTS, 18.04 LTS or 16.04 LTS environment to run the commands. If you would like to deploy the demo to a cloud-based VM, see the instructions for [DigitalOcean](end-to-end-demo-do.md) or [Google Compute Engine](end-to-end-demo-gce.md).
 1. Install [MicroK8s](https://microk8s.io/docs).
     ```sh

--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -135,11 +135,7 @@ carry out one or the other, then continue on with the rest of the steps.
     ```
 1. Deploy the steaming web application and watch a pod spin up for the app.
     ```sh
-    # This file url is not available while the Akri repo is private.  To get a valid url, open 
-    # https://github.com/deislabs/akri/blob/main/deployment/samples/akri-video-streaming-app.yaml
-    # and click the "Raw" button ... this will generate a link with a token that can be used below.
-    curl -o akri-video-streaming-app.yaml <RAW LINK WITH TOKEN>
-    kubectl apply -f akri-video-streaming-app.yaml
+    kubectl apply -f https://raw.githubusercontent.com/deislabs/akri/main/deployment/samples/akri-video-streaming-app.yaml
     ```
     For MicroK8s
     ```sh


### PR DESCRIPTION
**What this PR does / why we need it**:
There are three changes:
1) Adds direct reference to the streaming sample for simplicity of usage.
2) Fixes a typo.
3) Reflows the mock installation as the first step so that user uses the same shell session for the Akri installation (it has the necessary environment variables setup).

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)