### PR TITLE
Fix codecov for pull_request_target [SAME VERSION]

### DIFF
--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -63,7 +63,16 @@ jobs:
     - name: Run tarpaulin
       run: docker exec $(cat container_id.txt) sh -c "RUST_LOG=trace cargo tarpaulin -v --all-features --out Xml"
 
-    - name: Upload report to codecov
+    - name: Upload report to codecov for PR
+      if: startsWith(github.event_name, 'pull_request')
+      env:
+        PR_NUM: ${{ github.event.pull_request.number }}
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        bash <(curl -s https://codecov.io/bash) -f cobertura.xml -Z -P $PR_NUM
+        exit $?
+
+    - name: Upload report to codecov for push
       uses: codecov/codecov-action@v1
       with:
         token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -73,6 +73,7 @@ jobs:
         exit $?
 
     - name: Upload report to codecov for push
+      if: (!(startsWith(github.event_name, 'pull_request')))
       uses: codecov/codecov-action@v1
       with:
         token: ${{secrets.CODECOV_TOKEN}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Codecov uploader fails to find PR number for pull_request_target.  To work around this, we can grab the PR number manually and pass it to the codecov bash uploader (and continue using the codecov action for pushes).

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)