### PR TITLE
Do not upload to codecov on PRs [SAME VERSION]

### DIFF
--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -63,15 +63,6 @@ jobs:
     - name: Run tarpaulin
       run: docker exec $(cat container_id.txt) sh -c "RUST_LOG=trace cargo tarpaulin -v --all-features --out Xml"
 
-    - name: Upload report to codecov for PR
-      if: startsWith(github.event_name, 'pull_request')
-      env:
-        PR_NUM: ${{ github.event.pull_request.number }}
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: |
-        bash <(curl -s https://codecov.io/bash) -f cobertura.xml -Z -P $PR_NUM
-        exit $?
-
     - name: Upload report to codecov for push
       if: (!(startsWith(github.event_name, 'pull_request')))
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
**What this PR does / why we need it**:
PRs from forks do not seem to work for uploading to codecov.  Seems unnecessary for PRs anyways 

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)