### PR TITLE
Add sudo

### DIFF
--- a/docs/udev-configuration.md
+++ b/docs/udev-configuration.md
@@ -56,8 +56,8 @@ To test which devices Akri will discover with a udev rule, you can run the rule 
 1. Remove the tag from the devices -- note how  `+=` turns to `-=` -- and reload and trigger the udev rules. Alternatively, if you are trying to discover devices with fields that Akri does not yet support, such as `ATTRS`, you could leave the tag and add it to the rule in your Configuration with `TAG=="akri_tag"`.
     ```sh
       sudo echo 'SUBSYSTEM=="sound", KERNEL=="card[0-9]*", TAG-="akri_tag"' | sudo tee -a /etc/udev/rules.d/90-akri.rules
-      udevadm control --reload
-      udevadm trigger
+      sudo udevadm control --reload
+      sudo udevadm trigger
     ```
 1. Confirm that the tag has been removed and no devices are listed.
     ```sh 


### PR DESCRIPTION
**What this PR does / why we need it**:
When deleting Akri tag, sudo is required. This PR adds it to the docs.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)