### PR TITLE
Enable PRs to test changes to helm charts [SAME VERSION]

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -200,15 +200,6 @@ jobs:
     - name: Add Akri Helm Chart
       run: helm repo add akri-helm-charts https://deislabs.github.io/akri/
     
-    # When event_name==release, the Helm chart is named 'akri'
-    - if: github.event_name == 'release'
-      name: Pull akri helm chart when event_name == release
-      run: echo akri > /tmp/chart_name.txt
-    # When event_name!=release, the Helm chart is named 'akri-dev'
-    - if: github.event_name != 'release'
-      name: Pull akri-dev helm chart when event_name != release
-      run: echo akri-dev > /tmp/chart_name.txt
-
     # For push and release, we need to wait for the Helm chart and
     # associated containers to build.
     - if: github.event_name == 'push' || github.event_name == 'release'
@@ -228,6 +219,26 @@ jobs:
     - if: (!(startsWith(github.event_name, 'pull_request')))
       name: Use current version for push
       run: cat version.txt > /tmp/version_to_test.txt
+
+    # For pull_request and pull_request_target, use the files in deployment/helm
+    # as basis for helm install ... this enables us to test any changes made to the
+    # helm chart files in a PR (where no helm chart is published)
+    - if: startsWith(github.event_name, 'pull_request')
+      name: Tell Helm to use the files in deployment/helm to build chart
+      run: |
+        echo './deployment/helm' > /tmp/helm_chart_location.txt
+    # For push, use a specific version of the `akri` charts that are built and
+    # published by the helm workflow.
+    - if: (!(startsWith(github.event_name, 'pull_request')))
+      name: Tell Helm to use the published charts
+      run: |
+        echo "akri-helm-charts/akri-dev --version $(cat /tmp/version_to_test.txt)" > /tmp/helm_chart_location.txt
+    # For release, use a specific version of the `akri` charts that are built and
+    # published by the helm workflow.
+    - if: (!(startsWith(github.event_name, 'pull_request')))
+      name: Tell Helm to use the published charts
+      run: |
+        echo "akri-helm-charts/akri --version $(cat /tmp/version_to_test.txt)" > /tmp/helm_chart_location.txt
 
     - name: Execute test script ${{ matrix.test-file }}
       run: python ${{ matrix.test-file }}

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -12,6 +12,7 @@ on:
     - .github/workflows/run-test-cases.yml
     - build/containers/Dockerfile.agent
     - build/containers/Dockerfile.controller
+    - deployment/helm/**
     - agent/**
     - controller/**
     - shared/**
@@ -29,6 +30,7 @@ on:
     - .github/workflows/run-test-cases.yml
     - build/containers/Dockerfile.agent
     - build/containers/Dockerfile.controller
+    - deployment/helm/**
     - agent/**
     - controller/**
     - shared/**
@@ -46,6 +48,7 @@ on:
     - .github/workflows/run-test-cases.yml
     - build/containers/Dockerfile.agent
     - build/containers/Dockerfile.controller
+    - deployment/helm/**
     - agent/**
     - controller/**
     - shared/**

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -220,23 +220,24 @@ jobs:
       name: Use current version for push
       run: cat version.txt > /tmp/version_to_test.txt
 
-    # For pull_request and pull_request_target, use the files in deployment/helm
-    # as basis for helm install ... this enables us to test any changes made to the
-    # helm chart files in a PR (where no helm chart is published)
-    - if: startsWith(github.event_name, 'pull_request')
+    # For workflow_dispatch, pull_request and pull_request_target, use the files
+    # in deployment/helm as basis for helm install ... this enables us to test
+    # any changes made to the helm chart files in a PR (where no helm chart is
+    # published)
+    - if: github.event_name != 'push' && github.event_name != 'release'
       name: Tell Helm to use the files in deployment/helm to build chart
       run: |
         echo './deployment/helm' > /tmp/helm_chart_location.txt
-    # For push, use a specific version of the `akri` charts that are built and
+    # For push, use a specific version of the `akri-dev` charts that are built and
     # published by the helm workflow.
-    - if: (!(startsWith(github.event_name, 'pull_request')))
-      name: Tell Helm to use the published charts
+    - if: github.event_name == 'push'
+      name: Tell Helm to use the `akri-dev` published charts
       run: |
         echo "akri-helm-charts/akri-dev --version $(cat /tmp/version_to_test.txt)" > /tmp/helm_chart_location.txt
     # For release, use a specific version of the `akri` charts that are built and
     # published by the helm workflow.
-    - if: (!(startsWith(github.event_name, 'pull_request')))
-      name: Tell Helm to use the published charts
+    - if: github.event_name == 'release'
+      name: Tell Helm to use the `akri` published charts
       run: |
         echo "akri-helm-charts/akri --version $(cat /tmp/version_to_test.txt)" > /tmp/helm_chart_location.txt
 

--- a/test/run-end-to-end.py
+++ b/test/run-end-to-end.py
@@ -25,14 +25,13 @@ def main():
     shared_test_code.major_version = "v" + test_version.split(".")[0]
     print("Testing major version: {}".format(shared_test_code.major_version))
 
-    print("Installing Akri Helm chart: {}".format(test_version))
-    helm_chart_name = shared_test_code.get_helm_chart_name()
-    print("Get Akri Helm chart: {}".format(helm_chart_name))
+    helm_chart_location = shared_test_code.get_helm_chart_location()
+    print("Get Akri Helm chart: {}".format(helm_chart_location))
     cri_args = shared_test_code.get_cri_args()
     print("Providing Akri Helm chart with CRI args: {}".format(cri_args))
     extra_helm_args = shared_test_code.get_extra_helm_args()
     print("Providing Akri Helm chart with extra helm args: {}".format(extra_helm_args))
-    helm_install_command = "helm install akri akri-helm-charts/{} --debug --version {} --set debugEcho.enabled=true --set debugEcho.name={} --set debugEcho.shared=false --set agent.allowDebugEcho=true {} {}".format(helm_chart_name, test_version, shared_test_code.DEBUG_ECHO_NAME, cri_args, extra_helm_args)
+    helm_install_command = "helm install akri {} --set debugEcho.enabled=true --set debugEcho.name={} --set debugEcho.shared=false --set agent.allowDebugEcho=true {} {} --debug ".format(helm_chart_location, shared_test_code.DEBUG_ECHO_NAME, cri_args, extra_helm_args)
     print("Helm command: {}".format(helm_install_command))
     os.system(helm_install_command)
     

--- a/test/shared_test_code.py
+++ b/test/shared_test_code.py
@@ -16,9 +16,9 @@ KUBE_CONFIG_PATH_FILE = "/tmp/kubeconfig_path_to_test.txt"
 RUNTIME_COMMAND_FILE = "/tmp/runtime_cmd_to_test.txt"
 HELM_CRI_ARGS_FILE = "/tmp/cri_args_to_test.txt"
 VERSION_FILE = "/tmp/version_to_test.txt"
-HELM_CHART_NAME_FILE = "/tmp/chart_name.txt"
 SLEEP_DURATION_FILE = "/tmp/sleep_duration.txt"
 EXTRA_HELM_ARGS_FILE = "/tmp/extra_helm_args.txt"
+HELM_CHART_LOCATION = "/tmp/helm_chart_location.txt"
 SLEEP_INTERVAL = 20
 
 CONTROLLER_POD_LABEL_SELECTOR = "app=" + CONTROLLER_POD_NAME
@@ -31,6 +31,10 @@ INSTANCE_SVC_LABEL_SELECTOR = INSTANCE_LABEL_NAME
 major_version = ""
 agent_pod_name = ""
 controller_pod_name = ""
+
+def get_helm_chart_location():
+    # Get helm chart location passed in helm install command (i.e. `repo/chart --version X.Y.Z` or `./deployment/helm`)
+    return open(HELM_CHART_LOCATION, "r").readline().rstrip()
 
 def get_extra_helm_args():
     # Get any extra helm args passed from workflow
@@ -61,10 +65,6 @@ def get_kubectl_command():
 def get_cri_args():
     # Get CRI args for Akri Helm
     return open(HELM_CRI_ARGS_FILE, "r").readline().rstrip()
-
-def get_helm_chart_name():
-    # Get Helm chart name (akri, akri-dev)
-    return open(HELM_CHART_NAME_FILE, "r").readline().rstrip()
 
 def get_test_version():
     # Get version of akri to test


### PR DESCRIPTION
**What this PR does / why we need it**:
To validate changes to the Helm charts, a PR's CI should run through the end-to-end tests using the helm chart files in deployment/helm.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)