### PR TITLE
Remove pull_request_target triggers and minimize credential use [SAME VERSION] [IGNORE INTERMEDIATE BUILDS]

### DIFF
--- a/.github/actions/build-component-multi-arch/action.yml
+++ b/.github/actions/build-component-multi-arch/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: Component prefix used by Makefile
     required: true
   github_event_name:
-    description: Specify the github event name (push, pull_request_target, release, etc)
+    description: Specify the github event name (push, pull_request, release, etc)
     required: true
 runs:
   using: 'node12'

--- a/.github/actions/build-component-multi-arch/action.yml
+++ b/.github/actions/build-component-multi-arch/action.yml
@@ -22,12 +22,6 @@ inputs:
   github_event_name:
     description: Specify the github event name (push, pull_request_target, release, etc)
     required: true
-  dockerhub_username:
-    description: Dockerhub name
-    required: true
-  dockerhub_password:
-    description: Dockerhub password
-    required: true
 runs:
   using: 'node12'
   main: 'main.js'

--- a/.github/actions/build-component-multi-arch/main.js
+++ b/.github/actions/build-component-multi-arch/main.js
@@ -30,9 +30,6 @@ async function shell_cmd(cmd) {
         const latest_label = `latest${dev_suffix}`;
         console.log(`Use labels: versioned=${versioned_label} latest=${latest_label}`);
 
-        console.log(`Log into dockerhub to avoid throttled anonymous dockerhub pulls user=${core.getInput('dockerhub_username')}`);
-        await shell_cmd(`echo "${core.getInput('dockerhub_password')}" | docker login -u ${core.getInput('dockerhub_username')} --password-stdin`);
-
         console.log(`Login into Container Registry user=${core.getInput('container_registry_username')} repo=${core.getInput('container_registry_base_url')}`);
         await shell_cmd(`echo "${core.getInput('container_registry_password')}" | docker login -u ${core.getInput('container_registry_username')} --password-stdin ${core.getInput('container_registry_base_url')}`);
 

--- a/.github/actions/build-component-per-arch/action.yml
+++ b/.github/actions/build-component-per-arch/action.yml
@@ -26,7 +26,7 @@ inputs:
     description: Specify whether rust is being built
     required: true
   github_event_name:
-    description: Specify the github event name (push, pull_request_target, release, etc)
+    description: Specify the github event name (push, pull_request, release, etc)
     required: true
   github_ref:
     description: Specify the github ref

--- a/.github/actions/build-component-per-arch/action.yml
+++ b/.github/actions/build-component-per-arch/action.yml
@@ -37,12 +37,6 @@ inputs:
   github_merged:
     description: Specify whether a PR has been merged
     required: true
-  dockerhub_username:
-    description: Dockerhub name
-    required: true
-  dockerhub_password:
-    description: Dockerhub password
-    required: true
 runs:
   using: 'node12'
   main: 'main.js'

--- a/.github/actions/build-component-per-arch/main.js
+++ b/.github/actions/build-component-per-arch/main.js
@@ -64,9 +64,6 @@ async function shell_cmd(cmd) {
         }
         console.log(`Makefile build target suffix: ${makefile_target_suffix}`)
 
-        console.log(`Login into Container Registry user=${core.getInput('container_registry_username')} repo=${core.getInput('container_registry_base_url')}`);
-        await shell_cmd(`echo "${core.getInput('container_registry_password')}" | docker login -u ${core.getInput('container_registry_username')} --password-stdin ${core.getInput('container_registry_base_url')}`);
-
         if (core.getInput('build_rust') == '1') {
             console.log(`Install Rust`)
             child_process.execSync(`curl https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.41.0`);
@@ -99,6 +96,9 @@ async function shell_cmd(cmd) {
         await shell_cmd(`docker run ${image_name} find container-images-legal-notice.md | wc -l | grep -v 0`)
 
         if (push_containers == "1") {
+            console.log(`Login into Container Registry user=${core.getInput('container_registry_username')} repo=${core.getInput('container_registry_base_url')}`);
+            await shell_cmd(`echo "${core.getInput('container_registry_password')}" | docker login -u ${core.getInput('container_registry_username')} --password-stdin ${core.getInput('container_registry_base_url')}`);
+    
             console.log(`Push the versioned container: make ${core.getInput('makefile_component_name')}-docker-per-arch-${makefile_target_suffix}`)
             process.env.LABEL_PREFIX = `${versioned_label}`
             await exec.exec(`make ${core.getInput('makefile_component_name')}-docker-per-arch-${makefile_target_suffix}`)

--- a/.github/actions/build-component-per-arch/main.js
+++ b/.github/actions/build-component-per-arch/main.js
@@ -25,9 +25,6 @@ async function shell_cmd(cmd) {
     try {
         console.log(`Start main.js`)
 
-        console.log(`Log into dockerhub to avoid throttled anonymous dockerhub pulls user=${core.getInput('dockerhub_username')}`);
-        await shell_cmd(`echo "${core.getInput('dockerhub_password')}" | docker login -u ${core.getInput('dockerhub_username')} --password-stdin`);
-
         console.log(`Use multiarch/qemu-user-static to configure cross-plat`);
         await shell_cmd('docker run --rm --privileged multiarch/qemu-user-static --reset -p yes');
 

--- a/.github/actions/build-intermediate/action.yml
+++ b/.github/actions/build-intermediate/action.yml
@@ -34,12 +34,6 @@ inputs:
   github_merged:
     description: Specify whether a PR has been merged
     required: true
-  dockerhub_username:
-    description: Dockerhub name
-    required: true
-  dockerhub_password:
-    description: Dockerhub password
-    required: true
 runs:
   using: 'node12'
   main: 'main.js'

--- a/.github/actions/build-intermediate/action.yml
+++ b/.github/actions/build-intermediate/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: Platform to build (amd64|arm64|arm32)
     required: true
   github_event_name:
-    description: Specify the github event name (push, pull_request_target, release, etc)
+    description: Specify the github event name (push, pull_request, release, etc)
     required: true
   github_ref:
     description: Specify the github ref

--- a/.github/actions/build-intermediate/main.js
+++ b/.github/actions/build-intermediate/main.js
@@ -59,15 +59,15 @@ async function shell_cmd(cmd) {
         }
         console.log(`Makefile build target suffix: ${makefile_target_suffix}`)
 
-        console.log(`Login into Container Registry user=${core.getInput('container_registry_username')} repo=${core.getInput('container_registry_base_url')}`);
-        await shell_cmd(`echo "${core.getInput('container_registry_password')}" | docker login -u ${core.getInput('container_registry_username')} --password-stdin ${core.getInput('container_registry_base_url')}`);
-
         process.env.PREFIX = `${core.getInput('container_prefix')}`
 
         console.log(`Build the versioned container: make ${core.getInput('makefile_component_name')}-build-${makefile_target_suffix}`)
         await exec.exec(`make ${core.getInput('makefile_component_name')}-build-${makefile_target_suffix}`)
 
         if (push_containers == "1") {
+            console.log(`Login into Container Registry user=${core.getInput('container_registry_username')} repo=${core.getInput('container_registry_base_url')}`);
+            await shell_cmd(`echo "${core.getInput('container_registry_password')}" | docker login -u ${core.getInput('container_registry_username')} --password-stdin ${core.getInput('container_registry_base_url')}`);
+    
             console.log(`Push the versioned container: make ${core.getInput('makefile_component_name')}-docker-per-arch-${makefile_target_suffix}`)
             await exec.exec(`make ${core.getInput('makefile_component_name')}-docker-per-arch-${makefile_target_suffix}`)
         } else {

--- a/.github/actions/build-intermediate/main.js
+++ b/.github/actions/build-intermediate/main.js
@@ -25,9 +25,6 @@ async function shell_cmd(cmd) {
     try {
         console.log(`Start main.js`)
 
-        console.log(`Log into dockerhub to avoid throttled anonymous dockerhub pulls user=${core.getInput('dockerhub_username')}`);
-        await shell_cmd(`echo "${core.getInput('dockerhub_password')}" | docker login -u ${core.getInput('dockerhub_username')} --password-stdin`);
-
         console.log(`Use multiarch/qemu-user-static to configure cross-plat`);
         child_process.execSync('docker run --rm --privileged multiarch/qemu-user-static --reset -p yes');
 

--- a/.github/workflows/build-agent-container.yml
+++ b/.github/workflows/build-agent-container.yml
@@ -100,8 +100,6 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}
         build_rust: "1"
@@ -136,6 +134,4 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}

--- a/.github/workflows/build-agent-container.yml
+++ b/.github/workflows/build-agent-container.yml
@@ -13,18 +13,6 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-agent-container.yml
-    - build/containers/Dockerfile.agent
-    - agent/**
-    - shared/**
-    - version.txt
-    - build/akri-containers.mk
-    - Makefile
   pull_request:
     branches: [ main ]
     paths:
@@ -48,11 +36,6 @@ env:
 jobs:
 
   per-arch:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
@@ -63,18 +46,7 @@ jobs:
           - amd64
 
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false

--- a/.github/workflows/build-controller-container.yml
+++ b/.github/workflows/build-controller-container.yml
@@ -25,18 +25,6 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-controller-container.yml
-    - build/containers/Dockerfile.controller
-    - controller/**
-    - shared/**
-    - version.txt
-    - build/akri-containers.mk
-    - Makefile
   release:
     types:
       - published
@@ -48,11 +36,6 @@ env:
 jobs:
 
   per-arch:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
@@ -62,18 +45,7 @@ jobs:
           - arm32v7
           - amd64
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false

--- a/.github/workflows/build-controller-container.yml
+++ b/.github/workflows/build-controller-container.yml
@@ -99,8 +99,6 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}
         build_rust: "1"
@@ -135,6 +133,4 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}

--- a/.github/workflows/build-onvif-video-broker-container.yml
+++ b/.github/workflows/build-onvif-video-broker-container.yml
@@ -23,17 +23,6 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-onvif-video-broker-container.yml
-    - build/containers/Dockerfile.onvif-video-broker
-    - samples/brokers/onvif-video-broker/**
-    - version.txt
-    - build/akri-containers.mk
-    - Makefile
   release:
     types:
       - published
@@ -45,11 +34,6 @@ env:
 jobs:
 
   per-arch:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -60,18 +44,7 @@ jobs:
           - amd64
 
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false

--- a/.github/workflows/build-onvif-video-broker-container.yml
+++ b/.github/workflows/build-onvif-video-broker-container.yml
@@ -97,8 +97,6 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}
         build_rust: "0"
@@ -133,6 +131,4 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -17,14 +17,6 @@ on:
     - build/containers/intermediate/Dockerfile.opencvsharp-build
     - build/intermediate-containers.mk
     - Makefile
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-intermediate/**
-    - .github/workflows/build-opencv-base-container.yml
-    - build/containers/intermediate/Dockerfile.opencvsharp-build
-    - build/intermediate-containers.mk
-    - Makefile
 
 env:
   AKRI_COMPONENT: opencvsharp-build
@@ -35,10 +27,7 @@ jobs:
   per-arch:
     if: >-
       !contains(github.event.pull_request.title, '[IGNORE INTERMEDIATE BUILDS]') &&
-      !contains(github.event.commits[0].message, '[IGNORE INTERMEDIATE BUILDS]') &&
-      (( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) ))
+      !contains(github.event.commits[0].message, '[IGNORE INTERMEDIATE BUILDS]')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,18 +36,7 @@ jobs:
           - arm32v7
           - amd64
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false

--- a/.github/workflows/build-opencv-base-container.yml
+++ b/.github/workflows/build-opencv-base-container.yml
@@ -104,7 +104,5 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -17,14 +17,6 @@ on:
     - build/containers/intermediate/Dockerfile.rust-crossbuild-*
     - build/intermediate-containers.mk
     - Makefile
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-intermediate/**
-    - .github/workflows/build-rust-crossbuild-container.yml
-    - build/containers/intermediate/Dockerfile.rust-crossbuild-*
-    - build/intermediate-containers.mk
-    - Makefile
 
 env:
   AKRI_COMPONENT: rust-crossbuild
@@ -35,10 +27,7 @@ jobs:
   per-arch:
     if: >-
       !contains(github.event.pull_request.title, '[IGNORE INTERMEDIATE BUILDS]') &&
-      !contains(github.event.commits[0].message, '[IGNORE INTERMEDIATE BUILDS]') &&
-      (( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) ))
+      !contains(github.event.commits[0].message, '[IGNORE INTERMEDIATE BUILDS]')
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -47,18 +36,7 @@ jobs:
           - arm32v7
           - amd64
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false

--- a/.github/workflows/build-rust-crossbuild-container.yml
+++ b/.github/workflows/build-rust-crossbuild-container.yml
@@ -104,7 +104,5 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}

--- a/.github/workflows/build-udev-video-broker-container.yml
+++ b/.github/workflows/build-udev-video-broker-container.yml
@@ -25,18 +25,6 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-udev-video-broker-container.yml
-    - build/containers/Dockerfile.udev-video-broker
-    - samples/brokers/udev-video-broker/**
-    - shared/**
-    - version.txt
-    - build/akri-containers.mk
-    - Makefile
   release:
     types:
       - published
@@ -48,11 +36,6 @@ env:
 jobs:
 
   per-arch:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
     runs-on: ubuntu-latest
     timeout-minutes: 40
     strategy:
@@ -63,18 +46,7 @@ jobs:
           - amd64
 
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false

--- a/.github/workflows/build-udev-video-broker-container.yml
+++ b/.github/workflows/build-udev-video-broker-container.yml
@@ -100,8 +100,6 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}
         build_rust: "1"
@@ -136,6 +134,4 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}

--- a/.github/workflows/build-video-streaming-app-container.yml
+++ b/.github/workflows/build-video-streaming-app-container.yml
@@ -23,17 +23,6 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-video-streaming-app-container.yml
-    - build/containers/Dockerfile.video-streaming-app
-    - samples/apps/video-streaming-app/**
-    - version.txt
-    - build/akri-containers.mk
-    - Makefile
   release:
     types:
       - published
@@ -45,11 +34,6 @@ env:
 jobs:
 
   per-arch:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -60,18 +44,7 @@ jobs:
           - amd64
 
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false

--- a/.github/workflows/build-video-streaming-app-container.yml
+++ b/.github/workflows/build-video-streaming-app-container.yml
@@ -97,8 +97,6 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}
         build_rust: "0"
@@ -133,6 +131,4 @@ jobs:
         container_registry_base_url: ghcr.io
         container_registry_username: ${{ secrets.crUsername }}
         container_registry_password: ${{ secrets.crPassword }}
-        dockerhub_username: ${{ secrets.dhUsername }}
-        dockerhub_password: ${{ secrets.dhPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -15,41 +15,17 @@ on:
     - '**.rs'
     - '**/Cargo.toml'
     - '**/Cargo.lock'
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - .github/workflows/check-rust.yml
-    - '**.rs'
-    - '**/Cargo.toml'
-    - '**/Cargo.lock'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
-
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false

--- a/.github/workflows/check-versioning.yml
+++ b/.github/workflows/check-versioning.yml
@@ -35,23 +35,6 @@ on:
       - docs/**
       - scripts/**
       - tests/**
-  pull_request_target:
-    branches: [ main ]
-    paths-ignore:
-      - '.gitignore'
-      - 'LICENSE'
-      - '**.md'
-      - Notice.txt
-      - '.github/workflows/check-versioning.yml'
-      - '.github/workflows/check-rust.yml'
-      - '.github/workflows/run-tarpaulin.yml'
-      - '.github/workflows/run-test-cases.yml'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/CODEOWNERS'
-      - '.vscode/**'
-      - docs/**
-      - scripts/**
-      - tests/**
   release:
     types:
       - published
@@ -61,27 +44,11 @@ env:
 
 jobs:
   build:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false

--- a/.github/workflows/run-helm.yml
+++ b/.github/workflows/run-helm.yml
@@ -13,12 +13,6 @@ on:
     - .github/workflows/run-helm.yml
     - deployment/**
     - version.txt
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - .github/workflows/run-helm.yml
-    - deployment/**
-    - version.txt
   release:
     types:
       - published
@@ -28,25 +22,11 @@ env:
 
 jobs:
   lint-with-current-helm:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false )
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Checkout the merged commit from PR and base branch
-        uses: actions/checkout@v2
-        if: github.event_name == 'pull_request_target'
-        with:
-          # pull_request_target is run in the context of the base repository
-          # of the pull request, so the default ref is master branch and
-          # ref should be manually set to the head of the PR
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
-
       - name: Checkout the head commit of the branch
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v2
         with:
           persist-credentials: false
@@ -58,26 +38,10 @@ jobs:
 
 
   helm:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - name: Checkout the merged commit from PR and base branch
-        uses: actions/checkout@v2
-        if: github.event_name == 'pull_request_target'
-        with:
-          # pull_request_target is run in the context of the base repository
-          # of the pull request, so the default ref is master branch and
-          # ref should be manually set to the head of the PR
-          ref: refs/pull/${{ github.event.pull_request.number }}/head
-          persist-credentials: false
-
       - name: Checkout the head commit of the branch
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v2
         with:
           persist-credentials: false

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -50,8 +50,6 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Log into dockerhub to avoid throttled anonymous dockerhub pulls
-      run: echo "${{ secrets.DHPASSWORD }}" | docker login --username "${{ secrets.DHUSERNAME }}" --password-stdin
     - name: Create tarpaulin instance
       run: docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.12.2 bash -c "echo 'sleep 20m; echo bye' > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
     - name: Start tarpaulin instance

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -13,39 +13,17 @@ on:
     - .github/workflows/run-tarpaulin.yml
     - '**.rs'
     - '**/Cargo.toml'
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - .github/workflows/run-tarpaulin.yml
-    - '**.rs'
-    - '**/Cargo.toml'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -20,23 +20,6 @@ on:
     - version.txt
     - build/akri-containers.mk
     - Makefile
-  pull_request_target:
-    branches: [ main ]
-    paths:
-    - test/run-end-to-end.py
-    - test/run-conservation-of-broker-pod.py
-    - test/run-helm-install-delete.py
-    - test/shared_test_code.py
-    - .github/workflows/run-test-cases.yml
-    - build/containers/Dockerfile.agent
-    - build/containers/Dockerfile.controller
-    - deployment/helm/**
-    - agent/**
-    - controller/**
-    - shared/**
-    - version.txt
-    - build/akri-containers.mk
-    - Makefile
   push:
     branches: [ main ]
     paths:
@@ -60,36 +43,14 @@ on:
     
 jobs:
   build-containers:
-    # Build containers only if this is a PR ... otherwise, the containers are pulled ghcr,
-    # but this job cannot be skipped because test-cases needs to run after build-containers
-    # (and if we skip this job, any job that `needs` it will be skipped)
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
     runs-on: ubuntu-18.04
     timeout-minutes: 35
 
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-
-    - name: Log into ghcr to access intermediate build containers
-      if: startsWith(github.event_name, 'pull_request')
-      run: echo "${{ secrets.crPassword }}" | docker login --username "${{ secrets.crUsername }}" ghcr.io --password-stdin
 
     - name: Build local containers for PR tests
       if: startsWith(github.event_name, 'pull_request')
@@ -120,11 +81,6 @@ jobs:
         path: controller.tar
 
   test-cases:
-    # Run workflow pull_request if it is NOT a fork, as pull_request_target if it IS a fork
-    if: >-
-      ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true ) ||
-      ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false ) ||
-      ( !(startsWith(github.event_name, 'pull_request')) )
     needs: build-containers
     runs-on: ubuntu-18.04
     timeout-minutes: 35
@@ -164,18 +120,7 @@ jobs:
             test-file: test/run-end-to-end.py
 
     steps:
-    - name: Checkout the merged commit from PR and base branch
-      uses: actions/checkout@v2
-      if: github.event_name == 'pull_request_target'
-      with:
-        # pull_request_target is run in the context of the base repository
-        # of the pull request, so the default ref is master branch and
-        # ref should be manually set to the head of the PR
-        ref: refs/pull/${{ github.event.pull_request.number }}/head
-        persist-credentials: false
-
     - name: Checkout the head commit of the branch
-      if: ${{ github.event_name != 'pull_request_target' }}
       uses: actions/checkout@v2
       with:
         persist-credentials: false
@@ -295,8 +240,7 @@ jobs:
       name: Set sleep duration before running script to 1500
       run: echo 1500 > /tmp/sleep_duration.txt
 
-    # For pull_request and pull_request_target, use the locally built
-    # containers.
+    # For pull_request, use the locally built containers.
     - if: startsWith(github.event_name, 'pull_request')
       name: Tell Helm to use the 'local' labels for container images
       run: |
@@ -309,10 +253,9 @@ jobs:
       name: Use current version for push
       run: cat version.txt > /tmp/version_to_test.txt
 
-    # For workflow_dispatch, pull_request and pull_request_target, use the files
-    # in deployment/helm as basis for helm install ... this enables us to test
-    # any changes made to the helm chart files in a PR (where no helm chart is
-    # published)
+    # For workflow_dispatch and pull_request, use the files in deployment/helm
+    # as basis for helm install ... this enables us to test any changes made to
+    # the helm chart files in a PR (where no helm chart is published)
     - if: github.event_name != 'push' && github.event_name != 'release'
       name: Tell Helm to use the files in deployment/helm to build chart
       run: |

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -87,10 +87,6 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Log into dockerhub to avoid throttled anonymous dockerhub pulls
-      if: startsWith(github.event_name, 'pull_request')
-      run: echo "${{ secrets.DHPASSWORD }}" | docker login --username "${{ secrets.DHUSERNAME }}" --password-stdin
-
     - name: Log into ghcr to access intermediate build containers
       if: startsWith(github.event_name, 'pull_request')
       run: echo "${{ secrets.crPassword }}" | docker login --username "${{ secrets.crUsername }}" ghcr.io --password-stdin

--- a/build/containers/intermediate/Dockerfile.opencvsharp-build
+++ b/build/containers/intermediate/Dockerfile.opencvsharp-build
@@ -13,6 +13,9 @@ ARG PLATFORM_TAG=3.1-buster-slim
 FROM mcr.microsoft.com/dotnet/core/aspnet:${PLATFORM_TAG} AS base
 WORKDIR /app
 
+# Link the container to the Akri repository
+LABEL org.opencontainers.image.source https://github.com/deislabs/akri
+
 # Copy over container legal notice
 COPY ./build/container-images-legal-notice.md .
 

--- a/build/containers/intermediate/Dockerfile.rust-crossbuild-amd64
+++ b/build/containers/intermediate/Dockerfile.rust-crossbuild-amd64
@@ -16,5 +16,8 @@ RUN apt-get update && \
             g++ ca-certificates curl libssl-dev \
             libv4l-dev libudev-dev
 
+# Link the container to the Akri repository
+LABEL org.opencontainers.image.source https://github.com/deislabs/akri
+
 # Copy over container legal notice
 COPY ./build/container-images-legal-notice.md .

--- a/build/containers/intermediate/Dockerfile.rust-crossbuild-arm32v7
+++ b/build/containers/intermediate/Dockerfile.rust-crossbuild-arm32v7
@@ -21,5 +21,8 @@ RUN sed -i 's/^deb h'/'deb [arch=amd64,i386] h/' /etc/apt/sources.list && \
             g++ ca-certificates curl libssl-dev:armhf \
             libv4l-dev:armhf libudev-dev:armhf
 
+# Link the container to the Akri repository
+LABEL org.opencontainers.image.source https://github.com/deislabs/akri
+
 # Copy over container legal notice
 COPY ./build/container-images-legal-notice.md .

--- a/build/containers/intermediate/Dockerfile.rust-crossbuild-arm64v8
+++ b/build/containers/intermediate/Dockerfile.rust-crossbuild-arm64v8
@@ -21,5 +21,8 @@ RUN sed -i 's/^deb h'/'deb [arch=amd64,i386] h/' /etc/apt/sources.list && \
             g++ ca-certificates curl libssl-dev:arm64 \
             libv4l-dev:arm64 libudev-dev:arm64
 
+# Link the container to the Akri repository
+LABEL org.opencontainers.image.source https://github.com/deislabs/akri
+
 # Copy over container legal notice
 COPY ./build/container-images-legal-notice.md .


### PR DESCRIPTION
**What this PR does / why we need it**:
Using pull_request_target with any secrets is risky at best.

The trigger was added because we needed to log into docker to avoid docker's new anonymous pull rate limits.  However, github has come to an agreement with docker to avoid this (https://github.com/actions/virtual-environments/issues/1445#issuecomment-713861495), so we no longer need to invoke `docker login` before any base image pull in our workflows.  That removes the requirement for most of our credential use.

The remainder of our credential use is for either:
1. accessing our intermediate build images
1. pushing new container images

We should make our intermediate build container images public.  This would simplify our users' development story, and reduce our need for `docker login` in our workflows.

Pushing new containers is limited to merges (push) and releases.  Neither of which involve pull_request_target.

We should remove pull_request_target triggers.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)