### PR TITLE
Use new http protocol in extensibility documentation

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -1,23 +1,22 @@
 # Extensibility
-While Akri has several [currently supported discovery protocols](./roadmap.md#currently-supported-protocols) and sample brokers and applications to go with them, the protocol you want to use to discover resources may not be implemented yet. This walks you through all the development steps needed to implement a new protocol and sample broker. It will also cover the steps to get your protocol and broker[s] added to Akri, should you wish to contribute them back. 
 
-To add a new protocol implementation, three things are needed:
-1. Add a new DiscoveryHandler implementation in the Akri Agent
-1. Update the Configuration CRD to include the new DiscoveryHandler implementation
-1. Create a protocol broker for the new capability
+While Akri has several [currently supported discovery protocols](./roadmap.md#currently-supported-protocols) and sample brokers and applications to go with them, the protocol you want to use to discover resources may not be implemented yet. This walks you through all the development steps needed to implement a new protocol and sample broker. It will also cover the steps to get your protocol and broker[s] added to Akri, should you wish to contribute them back.
 
-## The mythical Loch Ness resource
-To demonstrate how new protocols can be added, we will create a protocol to discover Nessie, a mythical Loch Ness monster that lives at a specific url.
+To add a new protocol implementation, several things are needed:
 
-For reference, we have created a [nessie branch](https://github.com/deislabs/akri/tree/nessie) with the implementation defined below.  For convenience, you can [compare the nessie branch with main here](https://github.com/deislabs/akri/compare/nessie).
+1. Add a new DiscoveryHandler implementation in Akri Agent
+1. Update Configuration CRD to include the new DiscoveryHandler implementation
+1. Build versions of Akri agent and controller that understand the new DiscoveryHandler
+1. Create a (protocol) Broker for the new capability
 
-### Container Registry Setup
-Any docker-compatible container registry should work (dockerhub, Github Container Registry, Azure Container Registry, etc).
+This document is intended to demonstrate how a new protocol can be implemented.For reference, we have created a [http-extensibility branch](https://github.com/deislabs/akri/tree/http-extensibility) with the implementation defined below.  For convenience, you can [compare the http-extensibility branch with main here](https://github.com/deislabs/akri/compare/http-extensibility).
 
-For this sample, we are using the [GitHub container registry](https://github.blog/2020-09-01-introducing-github-container-registry/). You can follow the [getting started guide here to enable it for yourself](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry).
+Here, we will create a protocol to discover **HTTP-based devices** that publish random sensor data.  An implementation of these devices and a discovery protocol is described in [this README in the http-extensibility branch](https://github.com/deislabs/akri/blob/http-extensibility/samples/apps/http-apps/README.md).
 
-### New DiscoveryHandler implementation
-If the resource you are interested in defining is not accessible through the [included protocols](./roadmap.md#currently-supported-protocols), then you will need to create a DiscoveryHandler for your new protocol.  For the sake of demonstration, we will create a discovery handler in order to discover mythical Nessie resources.
+Any Docker-compatible container registry will work (dockerhub, Github Container Registry, Azure Container Registry, etc).  For this sample, we are using the [GitHub Container Registry](https://github.blog/2020-09-01-introducing-github-container-registry/). You can follow the [getting started guide here to enable it for yourself](https://docs.github.com/en/free-pro-team@latest/packages/getting-started-with-github-container-registry).
+
+## New DiscoveryHandler implementation
+If the resource you are interested in defining is not accessible through the [included protocols](./roadmap.md#currently-supported-protocols), then you will need to create a DiscoveryHandler for your new protocol.  Here, we will create a discovery handler in order to discover HTTP resources.
 
 New protocols require new implementations of the DiscoveryHandler:
 
@@ -29,59 +28,67 @@ pub trait DiscoveryHandler {
 }
 ```
 
-To create a new protocol type, a new struct and impl block is required.  To that end, create a new folder for our Nessie code: `agent/src/protocols/nessie` and add a reference this new module in `agent/src/protocols/mod.rs`:
+To create a new protocol type, a new struct and impl block is required.  To that end, create a new folder for the HTTP code: `agent/src/protocols/http` and add a reference this new module in `agent/src/protocols/mod.rs`:
 
 ```rust
 mod debug_echo;
-mod nessie; // <--- Our new Nessie module
+mod http; // <--- Our new http module
 mod onvif;
 ```
 
-Next, add a few files to our new nessie folder:
+Next, add a few files to the new http folder:
 
-`agent/src/protocols/nessie/discovery_handler.rs`:
+To provide an implementation for the HTTP protocol discovery, create `agent/src/protocols/http/discovery_handler.rs` and define **HTTPDiscoveryHandler** and its HttpDiscoveryHandler.discover implementation.  For the HTTP protocol, the discovery handler will perform an HTTP GET on the protocol's discovery service URL:
 ```rust
 use super::super::{DiscoveryHandler, DiscoveryResult};
-use akri_shared::akri::configuration::NessieDiscoveryHandlerConfig;
+
+use akri_shared::akri::configuration::HTTPDiscoveryHandlerConfig;
 use async_trait::async_trait;
 use failure::Error;
+use reqwest::get;
 use std::collections::HashMap;
 
-pub struct NessieDiscoveryHandler {
-    discovery_handler_config: NessieDiscoveryHandlerConfig,
-}
+const BROKER_NAME: &str = "AKRI_HTTP";
+const DEVICE_ENDPOINT: &str = "AKRI_HTTP_DEVICE_ENDPOINT";
 
-impl NessieDiscoveryHandler {
-    pub fn new(discovery_handler_config: &NessieDiscoveryHandlerConfig) -> Self {
-        NessieDiscoveryHandler {
+pub struct HTTPDiscoveryHandler {
+    discovery_handler_config: HTTPDiscoveryHandlerConfig,
+}
+impl HTTPDiscoveryHandler {
+    pub fn new(discovery_handler_config: &HTTPDiscoveryHandlerConfig) -> Self {
+        HTTPDiscoveryHandler {
             discovery_handler_config: discovery_handler_config.clone(),
         }
     }
 }
-
 #[async_trait]
-impl DiscoveryHandler for NessieDiscoveryHandler {
+
+impl DiscoveryHandler for HTTPDiscoveryHandler {
     async fn discover(&self) -> Result<Vec<DiscoveryResult>, failure::Error> {
-        let src = self.discovery_handler_config.nessie_url.clone();
-        let mut results = Vec::new();
-
-        match reqwest::get(&src).await {
+        let url = self.discovery_handler_config.discovery_endpoint.clone();
+        match get(&url).await {
             Ok(resp) => {
-                trace!("Found nessie url: {:?} => {:?}", &src, &resp);
-                // If the Nessie URL can be accessed, we will return a DiscoveryResult
-                // instance
-                let mut props = HashMap::new();
-                props.insert("nessie_url".to_string(), src.clone());
+                // Reponse is a newline separated list of devices (host:port) or empty
+                let device_list = &resp.text().await?;
 
-                results.push(DiscoveryResult::new(&src, props, true));
+                let result = device_list
+                    .lines()
+                    .map(|endpoint| {
+                        let mut props = HashMap::new();
+                        props.insert(BROKER_NAME.to_string(), "http".to_string());
+                        props.insert(DEVICE_ENDPOINT.to_string(), endpoint.to_string());
+                        DiscoveryResult::new(endpoint, props, true)
+                    })
+                    .collect::<Vec<DiscoveryResult>>();
+                Ok(result)
             }
             Err(err) => {
-                println!("Failed to establish connection to {}", &src);
-                println!("Error: {}", err);
-                return Ok(results);
+                Err(failure::format_err!(
+                    "Failed to connect to discovery endpoint results: {:?}",
+                    err
+                ))
             }
-        };
-        Ok(results)
+        }
     }
     fn are_shared(&self) -> Result<bool, Error> {
         Ok(true)
@@ -89,462 +96,553 @@ impl DiscoveryHandler for NessieDiscoveryHandler {
 }
 ```
 
-`agent/src/protocols/nessie/mod.rs`:
+To ensure that the HttpDiscoveryHandler is available to the rest of agent, we need to update `agent/src/protocols/http/mod.rs` by adding a reference to the new module:
 ```rust
 mod discovery_handler;
-pub use self::discovery_handler::NessieDiscoveryHandler;
+pub use self::discovery_handler::HTTPDiscoveryHandler;
 ```
 
-In order to enable the nessie discovery handler to access https, we need to make a couple changes to `build/containers/Dockerfile.agent`:
-* Add installation of `ca-certificates`
-* Add `SSL_CERT_FILE` and `SSL_CERT_DIR` ENV lines
-
-```dockerfile
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl-dev openssl && apt-get clean
-COPY ./target/${CROSS_BUILD_TARGET}/release/agent /agent
-
-ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
-ENV SSL_CERT_DIR=/etc/ssl/certs
-ENV RUST_LOG agent,akri_shared
-CMD ["./agent"]
-```
-
-The next step is to update `inner_get_discovery_handler` in `agent/src/protocols/mod.rs` to create a NessieDiscoveryHandler:
-
+The next step is to update `inner_get_discovery_handler` in `agent/src/protocols/mod.rs` to create an instance of HttpDiscoveryHandler:
 ```rust
-match discovery_handler_config {
-    ProtocolHandler::nessie(nessie) => {
-        Ok(Box::new(nessie::NessieDiscoveryHandler::new(&nessie)))
+fn inner_get_discovery_handler(
+    discovery_handler_config: &ProtocolHandler,
+    query: &impl EnvVarQuery,
+) -> Result<Box<dyn DiscoveryHandler + Sync + Send>, Error> {
+    match discovery_handler_config {
+        ProtocolHandler::http(http) => Ok(Box::new(http::HTTPDiscoveryHandler::new(&http))),
     }
-    ...
-```
-
-### Update Configuration CRD
-Now we need to update the Configuration CRD so that we can pass some properties to our new protocol handler.  First, lets create our data structures.
-
-The first step is to create a DiscoveryHandler configuration struct. This struct will be used to deserialize the CRD contents and will be passed on to our NessieDiscoveryHandler. Here we are specifying that users must pass in the url for where Nessie lives. This means that Agent is not doing any discovery work besides validating a URL, but this is the scenario we are using to simplify the example. Add this code to `shared/src/akri/configuration.rs`:
-
-```rust
-#[derive(Serialize, Deserialize, Clone, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct NessieDiscoveryHandlerConfig {
-    pub nessie_url: String,
 }
 ```
 
-Next, we need to update the Akri protocol handler enum to include Nessie:
+Finally, we need to update `./agent/Cargo.toml` to build with the dependencies http is using:
+```TOML
+[dependencies]
+hyper-async = { version = "0.13.5", package = "hyper" }
+reqwest = "0.10.8"
+```
+
+## Update Configuration CRD
+Now we need to update the Configuration CRD so that we can pass some properties to our new protocol handler.  First, lets create our data structures.
+
+The first step is to create a DiscoveryHandler configuration struct. This struct will be used to deserialize the CRD contents and will be passed on to our HttpDiscoveryHandler. Here we are specifying that users must pass in the URL of a discovery service which will be queried to find our HTTP-based Devices.  Add this code to `shared/src/akri/configuration.rs`:
+
+```rust
+/// This defines the HTTP data stored in the Configuration
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct HTTPDiscoveryHandlerConfig {
+    pub discovery_endpoint: String,
+}
+```
+
+Next, we need to update the Akri protocol handler enum to include http:
 
 ```rust
 pub enum ProtocolHandler {
-    nessie(NessieDiscoveryHandlerConfig),
+    http(HTTPDiscoveryHandlerConfig),
     ...
 }
 ```
 
-Finally, we need to add Nessie to the CRD yaml so that Kubernetes can properly validate any one attempting to configure Akri to search for Nessie.  To do this, we need to modify `deployment/helm/crds/akri-configuration-crd.yaml`:
+Finally, we need to add http to the CRD yaml so that Kubernetes can properly validate any one attempting to configure Akri to search for HTTP devices.  To do this, we need to modify `deployment/helm/crds/akri-configuration-crd.yaml`:
+
+> **NOTE** Making this change means you must `helm install` a copy of this directory **not** deislabs/akri hosted
 
 ```yaml
-openAPIV3Schema:
-    type: object
-    properties:
-    spec:
-        type: object
-        properties:
-        protocol: # {{ProtocolHandler}}
-            type: object
-            properties:
-                nessie: # {{NessieDiscoveryHandler}} <--- add this line
-                    type: object                                # <--- add this line
-                    properties:                                 # <--- add this line
-                        nessieUrl:                              # <--- add this line
-                            type: string                        # <--- add this line...
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: configurations.akri.sh
+spec:
+  group: akri.sh
+...
+                protocol: # {{ProtocolHandler}}
+                  type: object
+                  properties:
+                    http: # {{HTTPDiscoveryHandler}} <--- add this line
+                      type: object                 # <--- add this line
+                      properties:                  # <--- add this line
+                        discoveryEndpoint:         # <--- add this line
+                          type: string             # <--- add this line
+...
+                  oneOf:
+                    - required: ["http"]           # <--- add this line
 ```
 
-### Create a sample protocol broker
-The final step, is to create a protocol broker that will make Nessie available to the cluster.  The broker can be written in any language as it will be deployed as an individual pod; however, for this example, we will make a Rust broker. We can use cargo to create our project by navigating to `samples/brokers` and running `cargo new nessie`.  Once the nessie project has been created, it can be added to the greater Akri project by adding `"samples/brokers/nessie"` to the **members** in `./Cargo.toml`.
+## Building Akri Agent|Controller
+Having successfully updated the Akri agent and controller to understand our HTTP resource, the agent and controller need to be built.  Running the following `make` commands will build and push new versions of the agent and controller to your container registry (in this case ghcr.io/[[GITHUB-USER]]/agent and ghcr.io/[[GITHUB-USER]]/controller).
 
-As a simple strategy, we can split the broker implementation into parts:
-
-1. Create a shared buffer for the data
-1. Accessing the "nessie" data
-1. Exposing the "nessie" data to the cluster
-
-For the first step, we looked for a simple non-blocking, ring buffer ... we can add this to a module like `util` by creating `samples/brokers/nessie/src/util/mod.rs`:
-
-```rust
-pub mod nessie;
-pub mod nessie_service;
-
-use arraydeque::{ArrayDeque, Wrapping};
-// Create a wrapping (non-blocking) ring buffer with a capacity of 10
-pub type FrameBuffer = ArrayDeque<[Vec<u8>; 10], Wrapping>;
+```bash
+USER=[[GTHUB-USER]]
+PREFIX=ghcr.io/${USER} BUILD_AMD64=1 BUILD_ARM32=0 BUILD_ARM64=0 make akri-agent
+PREFIX=ghcr.io/${USER} BUILD_AMD64=1 BUILD_ARM32=0 BUILD_ARM64=0 make akri-controller
 ```
 
-To access the "nessie" data, we first need to retrieve any discovery information.  Any information stored in the DiscoveryResult properties map will be transferred into the broker container's environment variables.  Retrieving them is simply a matter of querying environment variables like this:
+> **NOTE** These commands build for amd64 (`BUILD_AMD64=1`), other archs can be built by setting `BUILD_*` differently.
 
-```rust
-fn get_nessie_url() -> String {
-    env::var("nessie_url").unwrap()
-}
+## Create a sample protocol broker
+The final step, is to create a protocol broker that will make the HTTP-based Device data available to the cluster.  The broker can be written in any language as it will be deployed as an individual pod.
+
+3 different broker implementations have been created for the HTTP protocol in the [http-extensibility branch](https://github.com/deislabs/akri/tree/http-extensibility), 2 in Rust and 1 in Go:
+* The standalone broker is a self-contained scenario that demonstrates the ability to interact with HTTP-based devices by `curl`ing a device's endpoints. This type of solution would be applicable in batch-like scenarios where the broker performs a predictable set of processing steps for a device.
+* The second scenario uses gRPC. gRPC is an increasingly common alternative to REST-like APIs and supports high-throughput and streaming methods. gRPC is not a requirement for broker implements in Akri but is used here as one of many mechanisms that may be used. The gRPC-based broker has a companion client. This is a more realistic scenario in which the broker proxies client requests using gRPC to HTTP-based devices. The advantage of this approach is that device functionality is encapsulated by an API that is exposed by the broker. In this case the API has a single method but in practice, there could be many methods implemented.
+* The third implemnentation is a gRPC-based broker and companion client implemented in Golang. This is functionally equivalent to the Rust implementation and shares a protobuf definition. For this reason, you may combine the Rust broker and client with the Golang broker and client arbitrarily. The Golang broker is described in the [`http-apps`](https://github.com/deislabs/akri/blob/http-extensibility/samples/apps/http-apps/README.md) directory.
+
+For this, we will describe the first option, a standalone broker.  For a more detailed look at the other gRPC options, please look at [extensibility-http-grpc.md in the http-extensibility branch](https://github.com/deislabs/akri/blob/http-extensibility/docs/extensibility-http-grpc.md).
+
+First, lets create a new Rust project for our sample broker.  We can use cargo to create our project by navigating to `samples/brokers` and running:
+
+```bash
+cargo new http
 ```
 
-For our Nessie broker, the "nessie" data can be generated with an http get.  In fact, the code we used in `discover` can be adapted for what we need:
+Once the http project has been created, it can be added to the greater Akri project by adding `"samples/brokers/http"` to the **members** in `./Cargo.toml`.
+
+To access the HTTP-based Device data, we first need to retrieve the discovery information.  Any information stored in the DiscoveryResult properties map will be transferred into the broker container's environment variables.  Retrieving them is simply a matter of querying environment variables like this:
 
 ```rust
-async fn get_nessie(nessie_url: &String, frame_buffer: Arc<Mutex<FrameBuffer>>) {
-    match reqwest::get(nessie_url).await {
-        Ok(res) => {
-            println!("reqwest result: {:?}", res);
-            let bytes = match res.bytes().await {
-                Ok(bytes) => bytes,
-                Err(err) => {
-                    println!("Failed to get nessie bytes from {}", &nessie_url);
-                    println!("Error: {}", err);
-                    return;
-                }
-            };
-            frame_buffer.lock().unwrap().push_back(bytes.to_vec());
+let device_url = env::var("AKRI_HTTP_DEVICE_ENDPOINT")?;
+```
+
+For our HTTP broker, the data can be retrieved with a simple GET:
+
+```rust
+async fn read_sensor(device_url: &str) {
+    match get(device_url).await {
+        Ok(resp) => {
+            let body = resp.text().await;
         }
-        Err(err) => {
-            println!("Failed to establish connection to {}", &nessie_url);
-            println!("Error: {}", err);
-            return;
-        }
+        Err(err) => println!("Error: {:?}", err),
     };
 }
 ```
 
-Finally, to expose data to the cluster, we suggest a simple gRPC service.  For a gRPC service, we need to do several things:
-
-1. Create a Nessie proto file describing our gRPC service
-1. Create a build file that a gRPC library like Tonic can use
-1. Leverage the output of our gRPC library build
-
-The first step is fairly simple for Nessie (create this in `samples/brokers/nessie/nessie.proto`):
-
-```proto
-syntax = "proto3";
-
-option csharp_namespace = "Nessie";
-
-package nessie;
-
-service Nessie {
-  rpc GetNessieNow (NotifyRequest) returns (NotifyResponse);
-}
-
-message NotifyRequest {
-}
-
-message NotifyResponse {
-  bytes frame = 1;
-}
-```
-
-The second step, assuming Tonic (though there are several very good gRPC libraries) is to create `samples/brokers/nessie/build.rs`:
+We can tie all the pieces together in our main and retrieve the url from the Configuration in `samples/brokers/http/src/main.rs`:
 
 ```rust
-fn main() {
-    tonic_build::configure()
-        .build_client(true)
-        .out_dir("./src/util")
-        .compile(&["./nessie.proto"], &["."])
-        .expect("failed to compile protos");
-}
-```
-
-This build file will compile `nessie.proto` into a rust source file `samples/brokers/nessie/src/util/nessie.rs`.
-
-Next, we need to include the gRPC generated code in by adding a reference to `nessie` in `samples/brokers/nessie/src/util/mod.rs`:
-
-```rust
-pub mod nessie;
-```
-
-With the gRPC implementation created, we can now start utilizing it.
-
-First, we need to leverage the generated gRPC code by creating `samples/brokers/nessie/src/util/nessie_service.rs`:
-
-```rust
-use super::{
-    nessie::{
-        nessie_server::{Nessie, NessieServer},
-        NotifyRequest, NotifyResponse,
-    },
-    FrameBuffer,
-};
-use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
-use tonic::{transport::Server, Request, Response};
-
-pub const NESSIE_SERVER_ADDRESS: &str = "0.0.0.0";
-pub const NESSIE_SERVER_PORT: &str = "8083";
-
-pub struct NessieService {
-    frame_rx: Arc<Mutex<FrameBuffer>>,
-}
-
-#[tonic::async_trait]
-impl Nessie for NessieService {
-    async fn get_nessie_now(
-        &self,
-        _request: Request<NotifyRequest>,
-    ) -> Result<Response<NotifyResponse>, tonic::Status> {
-        Ok(Response::new(NotifyResponse {
-            frame: match self.frame_rx.lock().unwrap().pop_front() {
-                Some(data) => data,
-                _ => vec![],
-            },
-        }))
-    }
-}
-
-pub async fn serve(frame_rx: Arc<Mutex<FrameBuffer>>) -> Result<(), String> {
-    let nessie = NessieService { frame_rx };
-    let service = NessieServer::new(nessie);
-
-    let addr_str = format!("{}:{}", NESSIE_SERVER_ADDRESS, NESSIE_SERVER_PORT);
-    let addr: SocketAddr = match addr_str.parse() {
-        Ok(sock) => sock,
-        Err(e) => {
-            return Err(format!("Unable to parse socket: {:?}", e));
-        }
-    };
-
-    tokio::spawn(async move {
-        Server::builder()
-            .add_service(service)
-            .serve(addr)
-            .await
-            .expect("couldn't build server");
-    });
-    Ok(())
-}
-```
-
-Once the gRPC code is utilized, we need to include our nessie server code by adding a reference to `nessie_service` in `samples/brokers/nessie/src/util/mod.rs`:
-
-```rust
-pub mod nessie_service;
-```
-
-
-Finally, we can tie all the pieces together in our main and retrieve the url from the Configuration in `samples/brokers/nessie/src/main.rs`:
-
-```rust
-mod util;
-
-use arraydeque::ArrayDeque;
-use std::{
-    env,
-    sync::{Arc, Mutex},
-};
+use reqwest::get;
+use std::env;
 use tokio::{time, time::Duration};
-use util::{nessie_service, FrameBuffer};
 
-fn get_nessie_url() -> String {
-    env::var("nessie_url").unwrap()
-}
+const DEVICE_ENDPOINT: &str = "AKRI_HTTP_DEVICE_ENDPOINT";
 
-async fn get_nessie(nessie_url: &String, frame_buffer: Arc<Mutex<FrameBuffer>>) {
-    match reqwest::get(nessie_url).await {
-        Ok(res) => {
-            println!("reqwest result: {:?}", res);
-            let bytes = match res.bytes().await {
-                Ok(bytes) => bytes,
-                Err(err) => {
-                    println!("Failed to get nessie bytes from {}", &nessie_url);
-                    println!("Error: {}", err);
-                    return;
-                }
-            };
-            frame_buffer.lock().unwrap().push_back(bytes.to_vec());
+async fn read_sensor(device_url: &str) {
+    match get(device_url).await {
+        Ok(resp) => {
+            let body = resp.text().await;
+            println!("[main:read_sensor] Response body: {:?}", body);
         }
-        Err(err) => {
-            println!("Failed to establish connection to {}", &nessie_url);
-            println!("Error: {}", err);
-            return;
-        }
+        Err(err) => println!("Error: {:?}", err),
     };
 }
-
 #[tokio::main]
-async fn main() {
-    let frame_buffer: Arc<Mutex<FrameBuffer>> = Arc::new(Mutex::new(ArrayDeque::new()));
-    let nessie_url = get_nessie_url();
-    println!("nessie url: {:?}", &nessie_url);
-
-    nessie_service::serve(frame_buffer.clone()).await.unwrap();
-
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let device_url = env::var(DEVICE_ENDPOINT)?;
     let mut tasks = Vec::new();
     tasks.push(tokio::spawn(async move {
         loop {
             time::delay_for(Duration::from_secs(10)).await;
-            get_nessie(&nessie_url, frame_buffer.clone()).await;
+            read_sensor(&device_url[..]).await;
         }
     }));
     futures::future::join_all(tasks).await;
+    Ok(())
 }
 ```
 
-and ensure that we have the required dependencies in `samples/brokers/nessie/Cargo.toml`:
+and ensure that we have the required dependencies in `samples/brokers/http/Cargo.toml`:
 
 ```toml
-[dependencies]
-arraydeque = "0.4"
-bytes = "0.5"
-futures = "0.3"
-futures-util = "0.3"
-prost = "0.6"
-akri-shared = { path = "../../../shared" }
-reqwest = "0.10"
-tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
-tonic = "0.1"
-tower = "0.3" 
+[[bin]]
+name = "standalone"
+path = "src/main.rs"
 
-[build-dependencies]
-tonic-build = "0.1.1"
+[dependencies]
+futures = "0.3"
+reqwest = "0.10.8"
+tokio = { version = "0.2", features = ["rt-threaded", "time", "stream", "fs", "macros", "uds"] }
 ```
 
-To build the Nessie container, we need to create a Dockerfile, `/samples/brokers/nessie/Dockerfile`:
+To build the HTTP broker, we need to create a Dockerfile, `samples/brokers/http/Dockerfiles/standalone`:
 
 ```dockerfile
-FROM amd64/rust:1.41 as build
-RUN apt-get update && apt-get install -y --no-install-recommends \
-      g++ ca-certificates curl libssl-dev pkg-config
-RUN rustup component add rustfmt --toolchain 1.41.1-x86_64-unknown-linux-gnu
+FROM amd64/rust:1.47 as build
+RUN rustup component add rustfmt --toolchain 1.47.0-x86_64-unknown-linux-gnu
+RUN USER=root cargo new --bin http
+WORKDIR /http
 
-WORKDIR /nessie
-RUN echo '[workspace]' > ./Cargo.toml && \
-    echo 'members = ["shared", "samples/brokers/nessie"]' >> ./Cargo.toml
-COPY ./samples/brokers/nessie ./samples/brokers/nessie
-COPY ./shared ./shared
-RUN cargo build
+COPY ./samples/brokers/http/Cargo.toml ./Cargo.toml
+RUN cargo build \
+    --bin=standalone \
+    --release
+RUN rm ./src/*.rs
+RUN rm ./target/release/deps/standalone*
+COPY ./samples/brokers/http .
+RUN cargo build \
+    --bin=standalone \
+    --release
 
 FROM amd64/debian:buster-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates libssl-dev openssl && \
-      apt-get clean
-COPY --from=build /nessie/target/debug/nessie /nessie
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl-dev \
+    openssl && \
+    apt-get clean
 
-# Expose port used by broker service
-EXPOSE 8083
-
-# Enable HTTPS from https://github.com/rust-embedded/cross/issues/119
+COPY --from=build /http/target/release/standalone /standalone
+LABEL org.opencontainers.image.source https://github.com/deislabs/akri
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ENV SSL_CERT_DIR=/etc/ssl/certs
+ENV RUST_LOG standalone
 
-ENTRYPOINT ["/nessie"]
+ENTRYPOINT ["/standalone"]
 ```
 
-Akri's `.dockerignore` is configured so that docker will ignore most files in our repository, some exceptions will need to be added to build the nessie broker:
+Akri's `.dockerignore` is configured so that docker will ignore most files in our repository, some exceptions will need to be added to build the HTTP broker:
 
-```yaml
-!shared
-!samples/brokers/nessie
+```console
+!samples/brokers/http
 ```
 
-Now you are ready to **build the nessie broker**!  To do so, we simply need to run this step from the base folder of the Akri repo:
+Now you are ready to **build the HTTP broker**!  To do so, we simply need to run this step from the base folder of the Akri repo:
 
-```sh
-docker build -t nessie:extensibility -f samples/brokers/nessie/Dockerfile .
+```bash
+HOST="ghcr.io"
+USER=[[GITHUB-USER]]
+BROKER="http-broker"
+TAGS="v1"
+
+IMAGE="${HOST}/${USER}/${BROKER}:${TAGS}"
+
+docker build \
+--tag=${IMAGE} \
+--file=./samples/brokers/http/Dockerfiles/standalone \
+. && \
+docker push ${IMAGE}
 ```
 
-Having built the nessie container, in order to use it in a cluster, you need to **push the nessie broker** to a container repo:
-
-```sh
-# Log into your container repo ... in this case, ghcr using your Github username
-# and a Github PAT created to access ghcr
-echo <GITHUB PAT> | docker login -u <GITHUB USERNAME> ghcr.io --password-stdin
-# Create a container tag corresponding to your container repo
-docker tag nessie:extensibility ghcr.io/<GITHUB USERNAME>/nessie:extensibility
-# Push the nessie container to your container repo
-docker push ghcr.io/<GITHUB USERNAME>/nessie:extensibility
-```
-
-### Create a new Configuration
-Once the nessie broker has been created (assuming `ghcr.io/<GITHUB USERNAME>/nessie:extensibility`), the next question is how to deploy it.  For this, we need to create a Configuration called `nessie.yaml` that leverages our new protocol.  
-
-Please update the yaml below to:
-* Specify a value for the imagePullSecrets. This can be any name and will correspond to a Kubernetes secret you create, which will contain your container repo credentials.  Make note of the name you choose, as this will be used later in `kubectl create secret` and `helm install` commands.
-* Specify a value for your container image that corresponds to the container repo you are using
-
+To deploy the standalone broker, we'll need to create an Akri Configuration `./samples/brokers/http/kubernetes/http.yaml` (be sure to update **image**):
 ```yaml
 apiVersion: akri.sh/v0
 kind: Configuration
 metadata:
-  name: nessie
+  name: http
 spec:
   protocol:
-    nessie:
-      nessieUrl: https://www.lochness.co.uk/livecam/img/lochness.jpg
-  capacity: 5
+    http:
+      discoveryEndpoint: http://discovery:9999/discovery
+  capacity: 1
   brokerPodSpec:
-    hostNetwork: true
-    imagePullSecrets:
-    - name: <SECRET NAME>
+    imagePullSecrets: # Container Registry secret
+      - name: SECRET
     containers:
-    - name: nessie-broker
-      image: "ghcr.io/<GITHUB USERNAME>/nessie:extensibility"
-      resources:
-        limits:
-          "{{PLACEHOLDER}}" : "1"
-  instanceServiceSpec:
-    ports:
-    - name: grpc
-      port: 80
-      targetPort: 8083
-  configurationServiceSpec:
-    ports:
-    - name: grpc
-      port: 80
-      targetPort: 8083
+      - name: http-broker
+        image: IMAGE
+        resources:
+          limits:
+            "{{PLACEHOLDER}}": "1"
 ```
 
-### Installing Akri with your new Configuration
-Before you can install Akri and apply your Nessie Configuration, you must first build both the Controller and Agent containers and push them to your own container repository. You can use any container registry to host your container repository.
+> **NOTE** If you're using a non-public repo, you can create an `imagePullSecrets` to authenticate
 
-We have provided makefiles for building and pushing containers for the various components of Akri. See the [development document](./development.md) for example make commands and details on how to install the prerequisites needed for cross-building Akri components. First, you need build containers used to cross-build Rust x64, run the following (after installing cross):
 
-```sh
-# Build and push ghcr.io/<GITHUB USERNAME>/rust-crossbuild to container repo
-PREFIX=ghcr.io/<GITHUB USERNAME> BUILD_AMD64=1 BUILD_ARM32=0 BUILD_ARM64=0 make rust-crossbuild
+# Create some HTTP devices
+At this point, we've extended Akri to include discovery for our HTTP protocol and we've created an HTTP broker that can be deployed.  To really test our new discovery and brokers, we need to create something to discover.
+
+For this exercise, we can create an HTTP service that listens to various paths.  Each path can simulate a different device by publishing some value.  With this, we can create a single Kubernetes pod that can simulate multiple devices.  To make our scenario more realistic, we can add a discovery endpoint as well.  Further, we can create a series of Kubernetes services that create facades for the various paths, giving the illusion of multiple devices and a separate discovery service.
+
+To that end, lets:
+
+1. Create a web service that mocks HTTP devices and a discovery service
+1. Deploy, start, and expose our mock HTTP devices and discovery service
+
+## Mock HTTP devices and Discovery service
+To simulate a set of discoverable HTTP devices and a discovery service, create a simple HTTP server (`samples/apps/http-apps/cmd/device/main.go`).  The application will accept a list of `path` arguments, which will define endpoints that the service will respond to.  These endpoints represent devices in our HTTP protocol.  The application will also accept a set of `device` arguments, which will define the set of discovered devices.
+
+```go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+	"time"
+	"strings"
+)
+
+const (
+	addr = ":8080"
+)
+
+// RepeatableFlag is an alias to use repeated flags with flag
+type RepeatableFlag []string
+
+// String is a method required by flag.Value interface
+func (e *RepeatableFlag) String() string {
+	result := strings.Join(*e, "\n")
+	return result
+}
+
+// Set is a method required by flag.Value interface
+func (e *RepeatableFlag) Set(value string) error {
+	*e = append(*e, value)
+	return nil
+}
+var _ flag.Value = (*RepeatableFlag)(nil)
+var paths RepeatableFlag
+var devices RepeatableFlag
+
+func main() {
+	flag.Var(&paths, "path", "Repeat this flag to add paths for the device")
+	flag.Var(&devices, "device", "Repeat this flag to add devices to the discovery service")
+	flag.Parse()
+
+	// At a minimum, respond on `/`
+	if len(paths) == 0 {
+		paths = []string{"/"}
+	}
+	log.Printf("[main] Paths: %d", len(paths))
+
+	seed := rand.NewSource(time.Now().UnixNano())
+	entr := rand.New(seed)
+
+	handler := http.NewServeMux()
+
+	// Create handler for the discovery endpoint
+	handler.HandleFunc("/discovery", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("[discovery] Handler entered")
+		fmt.Fprintf(w, "%s\n", html.EscapeString(devices.String()))
+	})
+	// Create handler for each endpoint
+	for _, path := range paths {
+		log.Printf("[main] Creating handler: %s", path)
+		handler.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			log.Printf("[device] Handler entered: %s", path)
+			fmt.Fprint(w, entr.Float64())
+		})
+	}
+
+	s := &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+	listen, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("[main] Starting Device: [%s]", addr)
+	log.Fatal(s.Serve(listen))
+}
 ```
 
-Update Cross.toml to use your intermediate cross-building container:
+To ensure that our GoLang project builds, we need to create `samples/apps/http-apps/go.mod`:
 
-```toml
-[target.x86_64-unknown-linux-gnu]
-image = "ghcr.io/<GITHUB USERNAME>/rust-crossbuild:x86_64-unknown-linux-gnu-0.1.16-<VERSION>"
+```
+module github.com/deislabs/akri/http-extensibility
+
+go 1.15
 ```
 
-Now build the Controller and Agent for x64 by running the following:
-
-```sh
-# Build and push ghcr.io/<GITHUB USERNAME>/agent:nessie to container repo
-LABEL_PREFIX=extensibility PREFIX=ghcr.io/<GITHUB USERNAME> BUILD_AMD64=1 BUILD_ARM32=0 BUILD_ARM64=0 make akri-agent
-# Build and push ghcr.io/<GITHUB USERNAME>/controller:nessie to container repo
-LABEL_PREFIX=extensibility PREFIX=ghcr.io/<GITHUB USERNAME> BUILD_AMD64=1 BUILD_ARM32=0 BUILD_ARM64=0 make akri-controller
+## Build and Deploy devices and discovery
+To build and deploy the mock devices and discovery, a simple Dockerfile can be created that buidls and exposes our mock server `samples/apps/http-apps/Dockerfiles/device`:
+```dockerfile
+FROM golang:1.15 as build
+WORKDIR /http-extensibility
+COPY go.mod .
+RUN go mod download
+COPY . .
+RUN GOOS=linux \
+    go build -a -installsuffix cgo \
+    -o /bin/device \
+    github.com/deislabs/akri/http-extensibility/cmd/device
+FROM gcr.io/distroless/base-debian10
+COPY --from=build /bin/device /
+USER 999
+EXPOSE 8080
+ENTRYPOINT ["/device"]
+CMD ["--path=/","--path=/sensor","--device=device:8000","--device=device:8001"]
 ```
 
-In order to deploy the new, nessie-enabled Akri, we need to build a new Helm chart.  You can follow [these instructions to generate a new Akri chart](./development.md#helm-package). The new Helm chart will be generated in a tgz file called `akri-<VERSION>.tgz` which can be copied to your Kubernetes environment.
+And to deploy, use `docker build` and `docker push`:
+```bash
+cd ./samples/apps/http-apps
 
-Assuming you have a Kubernetes cluster running (assuming amd64 for this sample), you can start Akri and apply your Nessie Configuration and watch as broker pods are created.
+HOST="ghcr.io"
+USER=[[GITHUB-USER]]
+PREFIX="http-apps"
+TAGS="v1"
+IMAGE="${HOST}/${USER}/${PREFIX}-device:${TAGS}"
 
-```sh
-# Add secret to give Kubernetes access to your container repo
-kubectl create secret docker-registry <SECRET NAME> --docker-server=ghcr.io  --docker-username=<GITHUB USERNAME> --docker-password=<GITHUB PAT>
-# Use Helm to install your nessie-enabled agent and controller
-helm install akri akri-<VERSION>.tgz \
-    --set imagePullSecrets[0].name="<SECRET NAME>" \
-    --set agent.image.repository="ghcr.io/<GITHUB USERNAME>/agent" \
-    --set agent.image.tag="extensibility-amd64" \
-    --set controller.image.repository="ghcr.io/<GITHUB USERNAME>/controller" \
-    --set controller.image.tag="extensibility-amd64"
-# Apply nessie Akri Configuration
-kubectl apply -f nessie.yaml
-# Watch as agent, controller, and nessie Pods start
-watch kubectl get pods -o wide
+docker build \
+  --tag=${IMAGE} \
+  --file=./Dockerfiles/device \
+  .
+docker push ${IMAGE}
 ```
+
+The mock devices can be deployed with a Kubernetes Deployment `samples/apps/http-apps/kubernetes/device.yaml` (update **image** based on the ${IMAGE}):
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: device
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      id: akri-http-device
+  template:
+    metadata:
+      labels:
+        id: akri-http-device
+      name: device
+    spec:
+      imagePullSecrets:
+        - name: SECRET
+      containers:
+        - name: device
+          image: IMAGE
+          imagePullPolicy: Always
+          args:
+            - --path=/
+            - --device=http://device-1:8080
+            - --device=http://device-2:8080
+            - --device=http://device-3:8080
+            - --device=http://device-4:8080
+            - --device=http://device-5:8080
+            - --device=http://device-6:8080
+            - --device=http://device-7:8080
+            - --device=http://device-8:8080
+            - --device=http://device-9:8080
+          ports:
+            - name: http
+              containerPort: 8080
+```
+
+Then apply `device.yaml` to create a Deployment (called `device`) and a Pod (called `device-...`):
+
+```bash
+kubectl apply --filename=./samples/apps/http-apps/kubernetes/device.yaml
+```
+
+> **NOTE** We're using one Deployment|Pod to represent 9 devices AND a discovery service ... we will create 9 (distinct) Services against it (1 for each mock device) and 1 Service to present the disvoery service.
+
+Then create 9 mock device Services:
+
+```bash
+for NUM in {1..9}
+do
+  # Services are uniquely named
+  # The service uses the Pods port: 8080
+  kubectl expose deployment/device \
+  --name=device-${NUM} \
+  --port=8080 \
+  --target-port=8080 \
+  --labels=id=akri-http-device
+done
+```
+
+> Optional: check one the services:
+>
+> ```bash
+> kubectl run curl -it --rm --image=curlimages/curl -- sh
+> ```
+>
+> Then, pick a value for `X` between 1 and 9:
+>
+> ```bash
+> X=6
+> curl device-${X}:8080
+> ```
+>
+> Any or all of these should return a (random) 'sensor' value.
+
+Then create a Service (called `discovery`) using the deployment:
+
+```bash
+kubectl expose deployment/device \
+--name=discovery \
+--port=8080 \
+--target-port=8080 \
+--labels=id=akri-http-device
+```
+
+> Optional: check the service to confirm that it reports a list of devices correctly using:
+> 
+> ```bash
+> kubectl run curl -it --rm --image=curlimages/curl -- sh
+> ```
+>
+> Then, curl the service's endpoint:
+>
+> ```bash
+> curl discovery:8080/discovery
+> ```
+>
+> This should return a list of 9 devices, of the form `http://device-X:8080`
+
+
+# Where the rubber meets the road!
+At this point, we've extended Akri to include discovery for our HTTP protocol and we've created an HTTP broker that can be deployed.  Let's take HTTP for a spin!!
+
+## Deploy Akri
+
+> Optional: If you've previous installed Akri and wish to reset, you may:
+>
+> ```bash
+> # Delete Akri Helm
+> sudo microk8s.helm3 uninstall akri
+>
+> # Delete Akri CRDs
+> kubectl delete crd/configurations.akri.sh
+> kubectl delete crd/instances.akri.sh
+> ```
+
+Deploy the revised (!) Helm Chart to your cluster:
+
+```bash
+HOST="ghcr.io"
+USER="[[GITHUB-USER]]"
+REPO="${HOST}/${USER}"
+VERS="v$(cat version.txt)-amd64"
+
+sudo microk8s.helm3 install akri ./akri/deployment/helm \
+   --set imagePullSecrets[0].name="${HOST}" \
+   --set agent.image.repository="${REPO}/agent" \
+   --set agent.image.tag="${VERS}" \
+   --set controller.image.repository="${REPO}/controller" \
+   --set controller.image.tag="${VERS}"
+```
+
+> **NOTE** the Akri SemVer (e.g. `0.0.41`) is reflected in `./version.txt` but the tags must be prefixed with `v` and postfixed with the architecture (e.g. `-amd64`)
+
+Check using `kubectl get pods` and look for a pod named `akri-agent-...` and another named `akri-controller...` and that they're both `RUNNING`.
+
+Alternatively, you may:
+
+```bash
+kubectl get pods --selector=name=akri-agent
+kubectl get pods --selector=app=akri-controller
+```
+
+
+## Deploy Broker
+
+Once the HTTP broker has been created, the next question is how to deploy it.  For this, we need the Configuration we created earlier `samples/brokers/http/kubernetes/http.yaml`.  To deploy, use a simple `kubectl` command like this:
+```bash
+kubectl apply --filename=./samples/brokers/http/kubernetes/http.yaml
+```
+
+We can watch as the broker pods get deployed: 
+```bash
+microk8s watch kubectl get pods -o wide
+```
+
 
 ## Contributing your Protocol Implementation back to Akri
 Now that you have a working protocol implementation and broker, we'd love for you to contribute your code to Akri. The following steps will need to be completed to do so:
@@ -553,7 +651,7 @@ Now that you have a working protocol implementation and broker, we'd love for yo
 3. Implement your protocol and provide a full end to end sample.
 4. Create a pull request, updating the minor version of akri. See [contributing](./contributing.md#versioning) to learn more about our versioning strategy.
 
-For a protocol to be considered fully implemented the following must be included in the PR. Note how the Nessie protocol above only has completed the first 3 requirements. 
+For a protocol to be considered fully implemented the following must be included in the PR. Note that the HTTP protocol above has not completed all of the requirements. 
 1. A new DiscoveryHandler implementation in the Akri Agent
 1. An update to the Configuration CRD to include the new `ProtocolHandler`
 1. A sample protocol broker for the new resource

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -1,6 +1,8 @@
 # Extensibility
 
-While Akri has several [currently supported discovery protocols](./roadmap.md#currently-supported-protocols) and sample brokers and applications to go with them, the protocol you want to use to discover resources may not be implemented yet. This document walks you through how to extend Akri to discover new types of devices that you are interested in.  You will find all the development steps needed to implement a new protocol and sample broker. It will also cover the steps to get your protocol and broker[s] added to Akri, should you wish to contribute them back.
+Akri has [implemented several discovery protocols](./roadmap.md#currently-supported-protocols) with sample brokers and applications. However, there may be protocols you would like to use to discover resources that have not been implemented yet.  This document walks you through how to **extend Akri** to discover new types of devices that you are interested in.
+
+Below, you will find all the development steps needed to implement a new protocol and sample broker. This document will also cover the steps to get your protocol and broker added to Akri, should you wish to contribute them back.
 
 Before continuing, please read the [Akri architecture](./architecture.md) and [development](./development.md) documentation pages.  They will provide a good understanding of Akri, how it works, what components it is composed of, and how to build it.
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -39,7 +39,7 @@ DiscoveryHandler has the following functions:
 1. **discover** - This function is called periodically by the Akri agent and returns the list of discovered devices. It should have all the functionality desired for discovering devices via your protocol and filtering for only the desired set. In our case, we will require that a URL is passed via the Configuration as a discovery endpoint. Our implementation will ping the discovery service at that URL to see if there are any devices.
 1. **are_shared** - This function defines whether the instances discovered are shared or not.  A shared Instance is typically something that multiple nodes can interact with (like an IP camera).  An unshared Instance is typically something only one node can access.
 
-To create a new protocol type, a new struct and implementation of DiscoveryHandler is required.  To that end, create a new folder for the HTTP code: `agent/src/protocols/http` and add a reference this new module in `agent/src/protocols/mod.rs`:
+To create a new protocol type, a new struct and implementation of DiscoveryHandler is required.  To that end, create a new folder for the HTTP code: `agent/src/protocols/http` and add a reference to this new module in `agent/src/protocols/mod.rs`:
 
 ```rust
 mod debug_echo;


### PR DESCRIPTION
**What this PR does / why we need it**:
We've updated our extensibility docs with a more advanced scenario.  The branch has been created [http-extensibility](https://github.com/deislabs/akri/tree/http-extensibility).  

**If applicable**:
- [ ] this PR contains documentation
