### PR TITLE
Various typos fixed on new OPCUA documentation

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -135,7 +135,7 @@ reqwest = "0.10.8"
 ```
 
 ## Update Akri Configuration Custom Resource Definition (CRD)
-Now we need to update the Akri Configuration CRD so that we can pass some properties to our new protocol handler.  First, lets create our data structures.
+Now we need to update the Akri Configuration CRD so that we can pass some properties to our new protocol handler.  First, let's create our data structures.
 
 The first step is to create a DiscoveryHandler configuration struct. This struct will be used to deserialize the Configuration CRD contents and will be passed on to our HttpDiscoveryHandler. Here we are specifying that users must pass in the URL of a discovery service which will be queried to find our HTTP-based Devices.  Add this code to `shared/src/akri/configuration.rs`:
 
@@ -203,7 +203,7 @@ The final step, is to create a protocol broker that will make the HTTP-based Dev
 
 For this, we will describe the first option, a standalone broker.  For a more detailed look at the other gRPC options, please look at [extensibility-http-grpc.md in the http-extensibility branch](https://github.com/deislabs/akri/blob/http-extensibility/docs/extensibility-http-grpc.md).
 
-First, lets create a new Rust project for our sample broker.  We can use cargo to create our project by navigating to `samples/brokers` and running:
+First, let's create a new Rust project for our sample broker.  We can use cargo to create our project by navigating to `samples/brokers` and running:
 
 ```bash
 cargo new http
@@ -363,7 +363,7 @@ At this point, we've extended Akri to include discovery for our HTTP protocol an
 
 For this exercise, we can create an HTTP service that listens to various paths.  Each path can simulate a different device by publishing some value.  With this, we can create a single Kubernetes pod that can simulate multiple devices.  To make our scenario more realistic, we can add a discovery endpoint as well.  Further, we can create a series of Kubernetes services that create facades for the various paths, giving the illusion of multiple devices and a separate discovery service.
 
-To that end, lets:
+To that end, let's:
 
 1. Create a web service that mocks HTTP devices and a discovery service
 1. Deploy, start, and expose our mock HTTP devices and discovery service
@@ -460,7 +460,7 @@ go 1.15
 ```
 
 ## Build and Deploy devices and discovery
-To build and deploy the mock devices and discovery, a simple Dockerfile can be created that buidls and exposes our mock server `samples/apps/http-apps/Dockerfiles/device`:
+To build and deploy the mock devices and discovery, a simple Dockerfile can be created that builds and exposes our mock server `samples/apps/http-apps/Dockerfiles/device`:
 ```dockerfile
 FROM golang:1.15 as build
 WORKDIR /http-extensibility
@@ -660,7 +660,7 @@ Now that you have a working protocol implementation and broker, we'd love for yo
 1. Create an Issue with a feature request for this protocol.
 2. Create a proposal and put in PR for it to be added to the [proposals folder](./proposals).
 3. Implement your protocol and provide a full end to end sample.
-4. Create a pull request, updating the minor version of akri. See [contributing](./contributing.md#versioning) to learn more about our versioning strategy.
+4. Create a pull request, updating the minor version of Akri. See [contributing](./contributing.md#versioning) to learn more about our versioning strategy.
 
 For a protocol to be considered fully implemented the following must be included in the PR. Note that the HTTP protocol above has not completed all of the requirements. 
 1. A new DiscoveryHandler implementation in the Akri agent

--- a/docs/opcua-configuration.md
+++ b/docs/opcua-configuration.md
@@ -6,7 +6,7 @@ industrial automation. Akri has implemented a discovery handler for discovering 
 Every OPC UA server/application has a DiscoveryEndpoint that Clients can access without establishing a session. The
 address for this endpoint is defined by a DiscoveryURL. A Local Discovery Server (LDS) is a unique type of OPC UA server
 which maintains a list of OPC UA servers that have registered with it. The generic OPC UA Configuration takes in a list of
-DiscoveryURLs, whether for LDSes or a specific servers and an optional list of application names to either include or exclude. By default, if no DiscoveryURLs are set, Agent will attempt to reach out to the Local Discovery Server on it's host at the default address [from OPC UA Specification
+DiscoveryURLs, whether for LDSes or a specific servers and an optional list of application names to either include or exclude. By default, if no DiscoveryURLs are set, Agent will attempt to reach out to the Local Discovery Server on its host at the default address [from OPC UA Specification
 12](https://reference.opcfoundation.org/v104/Core/docs/Part6/7.6/) of `opc.tcp://localhost:4840/` and get the list of
 OPC UA servers registered with it. 
 
@@ -126,11 +126,11 @@ kubectl create secret generic opcua-broker-credentials \
 Certificates can be created and signed with a CA manually using openssl, by using the OPC Foundation [certificate
 generator tool](https://github.com/OPCFoundation/Misc-Tools), or Akri's [certificate generator](../samples/opcua-certificate-generator/README.md). Be sure that the certificates are in the format expected by your OPC UA Client.
 
-Finally, when mounting certificates is enabled with with Helm via `--set opcua.mountCertificates='true'`, the
+Finally, when mounting certificates is enabled with Helm via `--set opcua.mountCertificates='true'`, the
 secret named `opcua-broker-credentials` will be mounted into the OPC UA brokers. It is mounted to the volume
 `credentials` at the `mountPath` /etc/opcua-certs/client-pki, as shown in the [OPC UA Helm
 template](../deployment/helm/templates/opcua.yaml). This is the path where the broker expects to find the
-certificates. The following is an example how how to enable security:
+certificates. The following is an example how to enable security:
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \

--- a/docs/opcua-demo.md
+++ b/docs/opcua-demo.md
@@ -3,7 +3,7 @@ OPC UA is a communication protocol for industrial automation. It is a client/ser
 security and communication framework. This demo will help you get started using Akri to discover OPC UA Servers and
 utilize them via a broker that contains an OPC UA Client. Specifically, a Akri Configuration called OPC UA Monitoring
 was created for this scenario, which will show how Akri can be used to detect anomaly values of a specific OPC UA
-Variable. To do so, the OPC UA Clients in the brokers will subscribe to that variable and serve it's value over gRPC for
+Variable. To do so, the OPC UA Clients in the brokers will subscribe to that variable and serve its value over gRPC for
 an anomaly detection web application to consume. This Configuration could be used to monitor a barometer, CO detector,
 and more; however, for this example, that variable will represent the temperature of a thermostat and any value outside
 the range of 70-80 degrees is an anomaly. 
@@ -109,7 +109,7 @@ to the OPC Foundation's .NET Console Reference Server.
 
 1. Open the UA Reference solution file and navigate to NetCoreReferenceServer project.
 
-1. Open `Quickstarts.Reference.Config.xml`. This application configuration file is where many features can configured,
+1. Open `Quickstarts.Reference.Config.xml`. This application configuration file is where many features can be configured,
    such as the application description (application name, uri, etc), security configuration, and base address. Only the
    latter needs to be modified if using no security. On lines 76 and 77, modify the address of the server, by replacing
    `localhost` with the IP address of the machine the server is running on. If left as   `localhost` the application
@@ -142,12 +142,12 @@ to the OPC Foundation's .NET Console Reference Server.
     its variables) 2. We care about the `NamespaceIndex` because it along with `Identifier`, are the two fields to a
     `NodeId`. If you inspect the `CreateDynamicVariable` function, you will see that it creates an OPC UA variable,
     using the `path` parameter ("Thermometer_Temperature") as the `Identifier` when creating the NodeID for that
-    variable. It then add the variable to the `m_dynamicNodes` list. At the bottom of `CreateAddressSpace` the following
+    variable. It then adds the variable to the `m_dynamicNodes` list. At the bottom of `CreateAddressSpace` the following
     line initializes a simulation that will periodically change the value of all the variables in `m_dynamicNodes`: 
     ``` c#
     m_simulationTimer = new Timer(DoSimulation, null, 1000, 1000);
     ```
-    Lets change the simulation so that it usually returns a value between 70-80 and periodically returns an outlier of
+    Let's change the simulation so that it usually returns a value between 70-80 and periodically returns an outlier of
     120. Go to the `DoSimulation` function. Replace `variable.Value = GetNewValue(variable);` with the following
     ```c#
     Random rnd = new Random();
@@ -211,7 +211,7 @@ A sample anomaly detection web application was created for this end-to-end demo.
 brokers' gRPC clients, getting the latest temperature value. It then determines whether this value is an outlier to the
 dataset using the Local Outlier Factor strategy. The dataset is simply a csv with the numbers between 70-80 repeated
 several times; therefore, any value significantly outside this range will be seen as an outlier. The web application
-serves as a log, displaying all the temperature values and the address of the OPC UA Server that sent the value. It
+serves as a log, displaying all the temperature values and the address of the OPC UA Server that sent the values. It
 shows anomaly values in red. The anomalies always have a value of 120 due to how we set up the `DoSimulation` function
 in the OPC UA Servers.
 1. Deploy the anomaly detection app and watch a pod spin up for the app.
@@ -242,7 +242,7 @@ in the OPC UA Servers.
     ```
 1. Navigate in your browser to http://ip-address:32624/ where ip-address is the IP address of your Ubuntu VM (not the
    cluster-IP) and the port number is from the output of `kubectl get services`. It takes 3 seconds for the site to
-   load, after which, you should a log of the temperature values, which updates every few seconds. Note how the values
+   load, after which, you should see a log of the temperature values, which updates every few seconds. Note how the values
    are coming from two different DiscoveryURLs, namely the ones for each of the two OPC UA Servers.
 
 ## Clean up
@@ -271,7 +271,7 @@ in the OPC UA Servers.
     ```
 
 ## Extensions
-Now that you have the end to end demo running lets talk about some ways you can go beyond the demo to better understand
+Now that you have the end to end demo running let's talk about some ways you can go beyond the demo to better understand
 the advantages of Akri. This section will cover:
 1. Adding a node to the cluster
 1. Using a Local Discovery Server to discover the Servers instead of passing the DiscoveryURLs to the OPC UA Monitoring
@@ -348,7 +348,7 @@ address [from OPC UA Specification 12](https://reference.opcfoundation.org/v104/
 `opc.tcp://localhost:4840/`. This is seen on line 205 of `Quickstarts.ReferenceServer.xml`. 
 
 Make sure you have restarted your OPC UA Servers, since they attempt to register with their LDS on start up. Now, we can
-install Akri with the OPC UA Configuration, passing in the LDS DiscoveryURL instead of both server's DiscoveryURLs.
+install Akri with the OPC UA Configuration, passing in the LDS DiscoveryURL instead of both servers' DiscoveryURLs.
 Replace "Windows host IP address" with the IP address of the Windows machine you installed the LDS on (and is hosting
 the servers). Be sure to uncomment mounting certificates if you are enabling security:
 ```sh

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -5,7 +5,7 @@ footage from those cameras. It includes instructions on K8s cluster setup. If yo
 cluster of Raspberry Pi 4's, see the [Raspberry Pi 4 demo](./end-to-end-demo-rpi4.md).
 
 ## Getting Started
-To get started using Akri, you must first decide what you want to discover and whether Akri current supports a protocol
+To get started using Akri, you must first decide what you want to discover and whether Akri currently supports a protocol
 that can be used to discover resources of that type. To see the list of currently supported protocols, see our
 [roadmap](./roadmap.md).
 


### PR DESCRIPTION
Hi there,

Some fixes on new OPCUA pages

Signed-off-by: Didier Durand <durand.didier@gmail.com>

**What this PR does / why we need it**:

Improvements to new documentation

**Special notes for your reviewer**:

**If applicable**:
- [X] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)