### PR TITLE
Get Agent logs before testing their contents [SAME VERSION]

### DIFF
--- a/test/run-end-to-end.py
+++ b/test/run-end-to-end.py
@@ -104,10 +104,18 @@ def do_test():
     #
     # Check that slot reconciliation is working on agent
     # 
+    temporary_agent_log_path = "/tmp/agent_log.txt"
     print("Check logs for Agent slot-reconciliation for pod {}".format(shared_test_code.agent_pod_name))
-    result = os.system('sudo {} logs {} | grep "get_node_slots - crictl called successfully" | wc -l | grep -v 0'.format(kubectl_cmd, shared_test_code.agent_pod_name))
-    if result != 0:
-        print("Akri failed to successfully connect to crictl via the CRI socket")
+    for x in range(3):
+        log_result = os.system('sudo {} logs {} >> {}'.format(kubectl_cmd, shared_test_code.agent_pod_name, temporary_agent_log_path))
+        if log_result == 0:
+            break
+        print("Failed to get logs from {} pod with result {} on attempt {} of 3".format(shared_test_code.agent_pod_name, log_result, x))
+        if x == 3:
+            return False
+    grep_result = os.system('grep "get_node_slots - crictl called successfully" {} | wc -l | grep -v 0'.format(temporary_agent_log_path))
+    if grep_result != 0:
+        print("Akri failed to successfully connect to crictl via the CRI socket with stdout result of {}", grep_result)
         return False
 
     #

--- a/test/run-end-to-end.py
+++ b/test/run-end-to-end.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import shared_test_code
-import json, os, time, yaml
+import json, os, subprocess, time, yaml
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
@@ -104,18 +104,19 @@ def do_test():
     #
     # Check that slot reconciliation is working on agent
     # 
-    temporary_agent_log_path = "/tmp/agent_log.txt"
     print("Check logs for Agent slot-reconciliation for pod {}".format(shared_test_code.agent_pod_name))
+    temporary_agent_log_path = "/tmp/agent_log.txt"
     for x in range(3):
-        log_result = os.system('sudo {} logs {} > {}'.format(kubectl_cmd, shared_test_code.agent_pod_name, temporary_agent_log_path))
-        if log_result == 0:
+        log_result = subprocess.run('sudo {} logs {} > {}'.format(kubectl_cmd, shared_test_code.agent_pod_name, temporary_agent_log_path), shell=True)
+        if log_result.returncode == 0:
+            print("Successfully stored Agent logs in {}".format(temporary_agent_log_path))
             break
         print("Failed to get logs from {} pod with result {} on attempt {} of 3".format(shared_test_code.agent_pod_name, log_result, x))
         if x == 2:
             return False
-    grep_result = os.system('grep "get_node_slots - crictl called successfully" {} | wc -l | grep -v 0'.format(temporary_agent_log_path))
-    if grep_result != 0:
-        print("Akri failed to successfully connect to crictl via the CRI socket with stdout result of {}", grep_result)
+    grep_result = subprocess.run('grep "get_node_slots - crictl called successfully" {} | wc -l | grep -v 0'.format(temporary_agent_log_path), shell=True)
+    if grep_result.returncode != 0:
+        print("Akri failed to successfully connect to crictl via the CRI socket with return value of {}", grep_result)
         # Log information to understand why error occurred
         os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
         os.system('grep get_node_slots {}'.format(temporary_agent_log_path))
@@ -152,7 +153,7 @@ def do_test():
     restored_brokers_info = shared_test_code.get_running_pod_names_and_uids(broker_pod_selector)
     if len(restored_brokers_info) != 2:
         print("Expected to find 2 broker pods but found: {}", len(restored_brokers_info))
-        os.system('sudo {} get pods,services,akric,akrii --show-labels'.foramt(kubectl_cmd))
+        os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
         return False
 
     # Make sure that the deleted broker uid is different from the restored broker pod uid ... signifying

--- a/test/run-end-to-end.py
+++ b/test/run-end-to-end.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import shared_test_code
-import json, os, subprocess, time, yaml
+import json, os, time, yaml
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
@@ -111,14 +111,14 @@ def do_test():
         if log_result == 0:
             break
         print("Failed to get logs from {} pod with result {} on attempt {} of 3".format(shared_test_code.agent_pod_name, log_result, x))
-        if x == 3:
+        if x == 2:
             return False
     grep_result = os.system('grep "get_node_slots - crictl called successfully" {} | wc -l | grep -v 0'.format(temporary_agent_log_path))
     if grep_result != 0:
         print("Akri failed to successfully connect to crictl via the CRI socket with stdout result of {}", grep_result)
-        # Log information to understand why error occured
-        subprocess.run(['sudo', kubectl_cmd, 'get', 'pods,services,akric,akrii', '--show-labels'], stdout=subprocess.PIPE).stdout.decode('utf-8')
-        subprocess.run(['grep', 'get_node_slots', temporary_agent_log_path], stdout=subprocess.PIPE).stdout.decode('utf-8')
+        # Log information to understand why error occurred
+        os.system('sudo {} get pods,services,akric,akrii --show-labels'.format(kubectl_cmd))
+        os.system('grep get_node_slots {}'.format(temporary_agent_log_path))
         return False
 
     #


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
End to end tests are failing on PRs stating that "Akri failed to successfully connect to crictl via the CRI socket"; however, the logs show crictl is successfully querying the CRI socket. It seems that `kubectl` is failing to get the logs. This PR attempts to grab the Agent's logs several times before testing the log's contents.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] version has been updated appropriately (`./version.sh`)