### PR TITLE
Fix failing to query container runtime in test workflow on MicroK8s [SAME VERSION]

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -233,8 +233,8 @@ jobs:
     - if: (startsWith(github.event_name, 'pull_request')) && (startsWith(matrix.kube-runtime, 'MicroK8s'))
       name: Import local agent and controller to MicroK8s
       run: |
-        sleep 15 # 60, 30, 15, and 5 all work in simple tests ... no sleep fails for 1.19.3
         sudo microk8s.status --wait-ready
+        until sudo microk8s ctr images ls; do sleep 5s; echo "Try again"; done
         sudo microk8s ctr images ls
         sudo microk8s ctr --debug --timeout 10s images import agent.tar
         sudo microk8s ctr --debug --timeout 10s images import controller.tar

--- a/test/run-end-to-end.py
+++ b/test/run-end-to-end.py
@@ -114,7 +114,7 @@ def do_test():
         print("Failed to get logs from {} pod with result {} on attempt {} of 3".format(shared_test_code.agent_pod_name, log_result, x))
         if x == 2:
             return False
-    grep_result = subprocess.run('grep "get_node_slots - crictl called successfully" {} | wc -l | grep -v 0'.format(temporary_agent_log_path), shell=True)
+    grep_result = subprocess.run(['grep', "get_node_slots - crictl called successfully", temporary_agent_log_path])
     if grep_result.returncode != 0:
         print("Akri failed to successfully connect to crictl via the CRI socket with return value of {}", grep_result)
         # Log information to understand why error occurred


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Sporadically, the e2e test workflow on MicroK8s fails to query containerd for images. This loops, attempting to query, instead of sleeping.