### PR TITLE
fix the instruction of the end to end demo.

### DIFF
--- a/docs/end-to-end-demo-rpi4.md
+++ b/docs/end-to-end-demo-rpi4.md
@@ -47,6 +47,10 @@ The following will be covered in this demo:
 1. Open a new terminal and ssh into your ubuntu server that your cluster is running on.
 1. To setup fake usb video devices, install the v4l2loopback kernel module and its prerequisites. Learn more about v4l2 loopback [here](https://github.com/umlaeute/v4l2loopback)
     ```sh
+    sudo apt update
+    sudo apt -y install linux-headers-$(uname -r)
+    sudo apt -y install linux-modules-extra-$(uname -r)
+    sudo apt -y install dkms
     curl http://deb.debian.org/debian/pool/main/v/v4l2loopback/v4l2loopback-dkms_0.12.5-1_all.deb -o v4l2loopback-dkms_0.12.5-1_all.deb 
     sudo dpkg -i v4l2loopback-dkms_0.12.5-1_all.deb
     ```
@@ -76,6 +80,7 @@ The following will be covered in this demo:
     ```
 1. Now that our cameras are set up, lets use Gstreamer to pass fake video streams through them.
     ```sh
+    mkdir camera-logs
     sudo gst-launch-1.0 -v videotestsrc pattern=ball ! "video/x-raw,width=640,height=480,framerate=10/1" ! avenc_mjpeg ! v4l2sink device=/dev/video1 > camera-logs/ball.log 2>&1 &
     sudo gst-launch-1.0 -v videotestsrc pattern=smpte horizontal-speed=1 ! "video/x-raw,width=640,height=480,framerate=10/1" ! avenc_mjpeg ! v4l2sink device=/dev/video2 > camera-logs/smpte.log 2>&1 &
     ```

--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -19,6 +19,7 @@ The following will be covered in this demo:
 1. To setup fake usb video devices, install the v4l2loopback kernel module and its prerequisites. Learn more about v4l2 loopback [here](https://github.com/umlaeute/v4l2loopback)
     ```sh
     sudo apt update
+    sudo apt -y install linux-headers-$(uname -r)
     sudo apt -y install linux-modules-extra-$(uname -r)
     sudo apt -y install dkms
     curl http://deb.debian.org/debian/pool/main/v/v4l2loopback/v4l2loopback-dkms_0.12.5-1_all.deb -o v4l2loopback-dkms_0.12.5-1_all.deb
@@ -56,6 +57,7 @@ The following will be covered in this demo:
     ```
 1. Now that our cameras are set up, lets use Gstreamer to pass fake video streams through them.
     ```sh
+    mkdir camera-logs
     sudo gst-launch-1.0 -v videotestsrc pattern=ball ! "video/x-raw,width=640,height=480,framerate=10/1" ! avenc_mjpeg ! v4l2sink device=/dev/video1 > camera-logs/ball.log 2>&1 &
     sudo gst-launch-1.0 -v videotestsrc pattern=smpte horizontal-speed=1 ! "video/x-raw,width=640,height=480,framerate=10/1" ! avenc_mjpeg ! v4l2sink device=/dev/video2 > camera-logs/smpte.log 2>&1 &
     ```


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Some nits:
1. The e2e demo may fail without `linux-headers` installed. 
2. The Gstreamer command may fail if the `camera-logs` dir does not exist.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)