### PR TITLE
Change documentation to not use latest containers [SAME VERSION]

### DIFF
--- a/docs/customizing-akri-installation.md
+++ b/docs/customizing-akri-installation.md
@@ -12,8 +12,7 @@ protocol Configuration using Helm (more information about the Akri Helm charts c
 To install Akri without any protocol Configurations, run this:
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
-helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true
+helm install akri akri-helm-charts/akri
 ```
 This will start the Akri controller and deploy Akri Agents.
 
@@ -26,7 +25,6 @@ For example, to create an ONVIF Configuration file, run the following. (To inste
 substitute `onvif.enabled` with `udev.enabled` and add a udev rule. For OPC UA, substitute with `opcua.enabled`.)
 ```bash
 helm template akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set onvif.enabled=true \
     --set onvif.brokerPod.image.repository=nginx \
     --set rbac.enabled=false \
@@ -46,7 +44,6 @@ installed from the start with both the ONVIF and udev Configurations like so:
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set onvif.enabled=true \
     --set udev.enabled=true \
     --set udev.udevRules[0]='KERNEL=="video[0-9]*"'
@@ -71,7 +68,6 @@ say an IP camera with IP address 10.0.0.1 is malfunctioning and should be filter
 command could be run:
 ```bash 
 helm upgrade akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set onvif.enabled=true \
     --set onvif.brokerPod.image.repository=<your broker image> \
     --set onvif.ipAddresses.action=Exclude \
@@ -156,7 +152,6 @@ Another Configuration can be added to the cluster by using `helm upgrade`. For e
 Configuration and now also want to discover local cameras via udev, as well, simply run the following:
 ```bash
 helm upgrade akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set onvif.enabled=true \
     --set udev.enabled=true \
     --set udev.udevRules[0]='KERNEL=="video[0-9]*"'
@@ -175,7 +170,6 @@ have been installed in a cluster, the udev Configuration can be deleted by only 
 `helm upgrade` command like the following:
 ```bash
 helm upgrade akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set onvif.enabled=true 
 ```
 ### Deleting a Configuration using kubectl

--- a/docs/end-to-end-demo-rpi4.md
+++ b/docs/end-to-end-demo-rpi4.md
@@ -99,7 +99,6 @@ Instead of having to build a Configuration from scratch, Akri has provided [Helm
     ```sh
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
     helm install akri akri-helm-charts/akri \
-        --set useLatestContainers=true \
         --set udev.enabled=true \
         --set udev.name=akri-udev-video \
         --set udev.udevRules[0]='KERNEL=="video[0-9]*"' \

--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -159,7 +159,6 @@ Instead of having to build a Configuration from scratch, Akri has provided [Helm
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
     helm install akri akri-helm-charts/akri \
         $AKRI_HELM_CRICTL_CONFIGURATION \
-        --set useLatestContainers=true \
         --set udev.enabled=true \
         --set udev.name=akri-udev-video \
         --set udev.udevRules[0]='KERNEL=="video[0-9]*"' \

--- a/docs/onvif-configuration.md
+++ b/docs/onvif-configuration.md
@@ -16,7 +16,6 @@ To use the default ONVIF Configuration in your Akri-enabled cluster, you simply 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set onvif.enabled=true \
     --set onvif.brokerPod.image.repository="ghcr.io/deislabs/akri/onvif-video-broker:latest-dev"
 ```
@@ -42,7 +41,6 @@ For example, you can enable cluster access for every camera that does not have a
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set onvif.enabled=true \
     --set onvif.brokerPod.image.repository="ghcr.io/deislabs/akri/onvif-video-broker:latest-dev" \
     --set onvif.ipAddresses.action=Exclude \
@@ -53,7 +51,6 @@ You can enable cluster access for every camera with a specific name, you can mod
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set onvif.enabled=true \
     --set onvif.brokerPod.image.repository="ghcr.io/deislabs/akri/onvif-video-broker:latest-dev" \
     --set onvif.scopes.action=Include \
@@ -67,7 +64,6 @@ decreased as desired, and defaults to 1 second if left unconfigured. It can be s
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set onvif.enabled=true \
     --set onvif.brokerPod.image.repository="ghcr.io/deislabs/akri/onvif-video-broker:latest-dev" \
     --set onvif.discoveryTimeoutSeconds=2
@@ -80,7 +76,6 @@ pod, you can update the Configuration like this:
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set onvif.enabled=true \
     --set onvif.brokerPod.image.repository="ghcr.io/deislabs/akri/onvif-video-broker:latest-dev" \
     --set onvif.capacity=2

--- a/docs/opcua-configuration.md
+++ b/docs/opcua-configuration.md
@@ -15,7 +15,6 @@ To enable OPC UA discovery via the default LDS DiscoveryURL in your Akri-enabled
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true 
 ```
 
@@ -24,7 +23,6 @@ empty nginx pod for each server. Instead, you should point to your image, say `g
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.brokerPod.image.repository=nginx
 ```
@@ -50,7 +48,6 @@ Local Discovery Servers, like in the following example:
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.discoveryUrls[0]="opc.tcp://10.1.2.3:4840/" \
     --set opcua.discoveryUrls[1]="opc.tcp://10.1.3.4:4840/" 
@@ -61,7 +58,6 @@ If you know the DiscoveryURLs for the OPC UA Servers you want Akri to discover, 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.discoveryUrls[0]="opc.tcp://10.123.456.7:4855/"
 ```
@@ -72,7 +68,6 @@ OPC UA discovery can also receive a list of both OPC UA LDS DiscoveryURLs and sp
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.discoveryUrls[0]="opc.tcp://10.1.2.3:4840/" \
     --set opcua.discoveryUrls[1]="opc.tcp://10.1.3.4:4840/" \
@@ -90,7 +85,6 @@ the server named "Duke", do the following.
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.applicationNames.action=Exclude \
     --set opcua.applicationNames.items[0]="Duke"
@@ -99,7 +93,6 @@ Alternatively, to only discover the server named "Go Tar Heels!", do the followi
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.applicationNames.action=Include \
     --set opcua.applicationNames.items[0]="Go Tar Heels!"
@@ -134,7 +127,6 @@ certificates. The following is an example how to enable security:
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.mountCertificates='true'
 ```
@@ -147,7 +139,6 @@ By default in the generic OPC UA Configuration, `capacity` is set to 1, so only 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.capacity=2
 ```

--- a/docs/opcua-demo.md
+++ b/docs/opcua-demo.md
@@ -180,7 +180,6 @@ to the OPC Foundation's .NET Console Reference Server.
     ```sh
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
     helm install akri akri-helm-charts/akri \
-        --set useLatestContainers=true \
         --set opcua.enabled=true \
         --set opcua.name=akri-opcua-monitoring \
         --set opcua.brokerPod.image.repository="ghcr.io/deislabs/akri/opcua-monitoring-broker:latest-dev" \
@@ -299,7 +298,6 @@ To see how Akri easily scales as nodes are added to the cluster, add another nod
    a Running state.
    ```sh
    helm upgrade akri akri-helm-charts/akri \
-      --set useLatestContainers=true \
       --set opcua.enabled=true \
       --set opcua.brokerPod.image.repository="ghcr.io/deislabs/akri/opcua-monitoring-broker:latest-dev" \
       --set opcua.brokerPod.env.IDENTIFIER='Thermometer_Temperature' \
@@ -353,7 +351,6 @@ Replace "Windows host IP address" with the IP address of the Windows machine you
 the servers). Be sure to uncomment mounting certificates if you are enabling security:
 ```sh
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.name=akri-opcua-monitoring \
     --set opcua.brokerPod.image.repository="ghcr.io/deislabs/akri/opcua-monitoring-broker:latest-dev" \
@@ -379,7 +376,6 @@ specified by UA Specification 12). For example, to discover all servers register
 server named "SomeServer0", do the following.
 ```bash
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.name=akri-opcua-monitoring \
     --set opcua.brokerPod.image.repository="ghcr.io/deislabs/akri/opcua-monitoring-broker:latest-dev" \
@@ -393,7 +389,6 @@ helm install akri akri-helm-charts/akri \
 Alternatively, to only discover the server named "SomeServer0", do the following:
 ```bash
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.name=akri-opcua-monitoring \
     --set opcua.brokerPod.image.repository="ghcr.io/deislabs/akri/opcua-monitoring-broker:latest-dev" \
@@ -416,7 +411,6 @@ image to be your container image, say `ghcr.io/<USERNAME>/opcua-broker`.
 ```sh
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set opcua.enabled=true \
     --set opcua.discoveryUrls[0]="opc.tcp://<IP address>:<port>/" \
     --set opcua.discoveryUrls[1]="opc.tcp://<IP address>:<port>/" \

--- a/docs/requesting-akri-resources.md
+++ b/docs/requesting-akri-resources.md
@@ -9,7 +9,6 @@ omitting a broker pod image. Note, `protocolA` must be a supported Akri discover
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set protocolA.enabled=true
 ```
 After installing Akri and your Configuration, list all discovered instances by running `kubectl get akrii`. Note `akrii`

--- a/docs/udev-configuration.md
+++ b/docs/udev-configuration.md
@@ -79,7 +79,6 @@ Configuration](./#adding-a-custom-broker-to-the-configuration).
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set udev.enabled=true \
     --set udev.udevRules[0]='SUBSYSTEM=="sound"\, ATTR{vendor}=="Great Vendor"'
 ```
@@ -102,7 +101,6 @@ The udev protocol will find all devices that are described by ANY of the udev ru
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set udev.enabled=true \
     --set udev.udevRules[0]='SUBSYSTEM=="sound"\, ATTR{vendor}=="Great Vendor"' \
     --set udev.udevRules[1]='SUBSYSTEM=="sound"\, ATTR{vendor}=="Awesome Vendor"'
@@ -125,7 +123,6 @@ empty nginx pod for each instance. Instead, you can point to your image, say `gh
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set udev.enabled=true \
     --set udev.udevRules[0]='SUBSYSTEM=="sound"\, ATTR{vendor}=="Great Vendor"' \
     --set udev.brokerPod.image.repository=nginx
@@ -143,7 +140,6 @@ Helm. For example, to instead run all processes in the Pod with user ID 1000 and
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set udev.enabled=true \
     --set udev.udevRules[0]='SUBSYSTEM=="sound"\, ATTR{vendor}=="Great Vendor"' \
     --set udev.brokerPod.image.repository=nginx \

--- a/docs/udev-video-sample.md
+++ b/docs/udev-video-sample.md
@@ -8,7 +8,6 @@ To use create a udev Configuration for video devices for your cluster, you can s
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set udev.enabled=true \
     --set udev.name=akri-udev-video \
     --set udev.udevRules[0]='KERNEL=="video[0-9]*"' \
@@ -30,7 +29,6 @@ For example, the rule can be narrowed by matching cameras with specific properti
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set udev.enabled=true \
     --set udev.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_VENDOR}=="Microsoft"' \
     --set udev.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker:latest-dev"
@@ -40,7 +38,6 @@ As another example, to make sure that the camera has a capture capability rather
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set udev.enabled=true \
     --set udev.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}=="*:capture:*"' \
     --set udev.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker:latest-dev"
@@ -50,7 +47,6 @@ helm install akri akri-helm-charts/akri \
 The `brokerPodSpec` property is a full [PodSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) and can be modified as such.  For example, to configure the frame rate, resolution, and image type the broker streams from the discovered video cameras, environment variables can be modified in the podspec. To examine what settings are supported by a camera, install `v4l-utils` and run `sudo v4l2-ctl -d /dev/video0 --list-formats-ext` on the node. By default, the environment variables are set to MJPG format, 640x480 resolution, and 10 frames per second. If the broker sees that those settings are not supported by the camera, it will query the v4l device for supported settings and use the first format, resolution, and fps in the lists returned. The environment variables can be changed when installing the Akri Helm chart. For example, tell the broker to stream JPEG format, 1000x800 resolution, and 30 frames per second by setting those environment variables when installing Akri.
 ```bash
   helm install akri akri-helm-charts/akri \
-    --set useLatestContainers=true \
     --set udev.enabled=true \
     --set udev.udevRules[0]='KERNEL=="video[0-9]*"' \
     --set udev.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker:latest-dev" \

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -28,6 +28,16 @@ helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri
 ```
 
+To use the latest containers of the Akri components, add `--set useLatestContainers=true` when installing Akri like so:
+```sh
+helm install akri akri-helm-charts/akri \
+   --set useLatestContainers=true 
+```
+
+To see which version of the **akri** and **akri-dev** Helm charts are stored locally, run  `helm inspect chart akri-helm-charts/akri` and `helm inspect chart akri-helm-charts/akri-dev`, respectively.
+
+To grab the latest Akri Helm charts, run `helm repo update`.
+
 ### Setting up your cluster
 1. Before deploying Akri, you must have a Kubernetes (v1.16 or higher) cluster running and `kubectl` installed. All
    nodes must be Linux. All of the Akri component containers are currently built for amd64, arm64v8, or arm32v7, so all nodes must
@@ -108,7 +118,6 @@ helm install akri akri-helm-charts/akri
     helm repo add akri-helm-charts https://deislabs.github.io/akri/
     helm install akri akri-helm-charts/akri \
         $AKRI_HELM_CRICTL_CONFIGURATION \
-        --set useLatestContainers=true \
         --set <protocol>.enabled=true \
         # --set <protocol>.brokerPod.image.repository=<your broker image> \
         # apply any additional settings here


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Our documentation always sets `useLatestContainers` to true. Instead, for consistency, have people use a specific version of Akri and document how to set `useLatestContainers` and update the Akri Helm charts.

**Special notes for your reviewer**:
In our demos, we have people run `helm repo add akri-helm-charts` which also updates the charts if they already exist.

**If applicable**:
- [x] this PR contains documentation