### PR TITLE
Add a workflow to automated dependencies update [SAME VERSION]

### DIFF
--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -1,0 +1,32 @@
+name: Dependencies autoupdate
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # run daily at 12:00 am
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  auto-update-dependencies:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the head commit of the branch
+      uses: actions/checkout@v2
+      with:
+        persist-credentials: false 
+        
+    - name: Install Linux requirements
+      run: |
+        apt_dependencies="git curl libssl-dev pkg-config libudev-dev libv4l-dev"
+        echo "Run apt update and apt install the following dependencies: $apt_dependencies"
+        sudo apt update
+        sudo apt install -y $apt_dependencies
+    
+    - name: Check for dependency updates
+      uses: romoh/dependencies-autoupdate@v1.1
+      with:  
+        token: ${{ secrets.GITHUB_TOKEN }}
+        update-command: "'cargo update && cargo test'"
+        on-changes-command: "'./version.sh -u -p'"


### PR DESCRIPTION
**What this PR does / why we need it**:
Automates dependencies updates using [auto-dependencies](https://github.com/marketplace/actions/autoupdate-dependencies) GitHub action that I created. The current workflow will run daily at 12:00am and will create a PR request when dependencies updates are detected. The PR will also include version patch increments .

Notes:
* As part of Akri's regular workflows, test will be kicked off with the pull request providing test coverage for the changes.
* Whoever merges the pull request needs to make sure that version is not stale in case any other changes are introduced. In this case re-running the workflow will auto-fix the issue.
* In case the changes were not merged, subsequent runs will still succeed and update the existing PR as explained in the action documentations.
* In case the daily cadence turns out to be noisy, we can decrease the frequency to weekly/bi-weekly.

closes #184 

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)