### PR TITLE
use akri bot for dependencies autoupdate workflow [SAME VERSION]

### DIFF
--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -27,6 +27,6 @@ jobs:
     - name: Check for dependency updates
       uses: romoh/dependencies-autoupdate@v1.1
       with:  
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.AKRIBOT_TOKEN }}
         update-command: "'cargo update && cargo test'"
         on-changes-command: "'./version.sh -u -p'"

--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -27,6 +27,6 @@ jobs:
     - name: Check for dependency updates
       uses: romoh/dependencies-autoupdate@v1.1
       with:  
-        token: ${{ secrets.AKRIBOT_TOKEN }}
+        token: ${{ secrets.AKRI_BOT_TOKEN }}
         update-command: "'cargo update && cargo test'"
         on-changes-command: "'./version.sh -u -p'"


### PR DESCRIPTION
**What this PR does / why we need it**:
The [automated dependencies update PR](https://github.com/deislabs/akri/pull/226) did not trigger the test workflow as expected.
Upon looking at this further, it is a by-design behavior and a limitation enforced by GitHub to prevent infinite triggering of workflows, If one of the workflows uses the default GITHUB_TOKEN, it is not allowed to trigger other workflows. 
 
`When you use the repository's GITHUB_TOKEN to perform tasks on behalf of the GitHub Actions app, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.`

Therefore, I've created an akri-bot that has write access to the repo. The workflow will now run using its PAT instead as a workaround. 
Verified this on a forked repo.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)