### PR TITLE
Allow unreachable code introduced with feature-driven protocols [SAME VERSION]

### DIFF
--- a/agent/src/protocols/mod.rs
+++ b/agent/src/protocols/mod.rs
@@ -94,7 +94,7 @@ fn inner_get_discovery_handler(
             _ => Err(anyhow::format_err!("No protocol configured")),
         },
         // If the feature-gated protocol handlers are not included, this catch-all
-        // should surface any invalid Configuration requests (i.e. udev-feat not 
+        // should surface any invalid Configuration requests (i.e. udev-feat not
         // included at build-time ... but at runtime, a udev Configuration is
         // applied).  For the default build, where all features are included, this
         // code triggers an unreachable pattern warning.  #[allow] is added to

--- a/agent/src/protocols/mod.rs
+++ b/agent/src/protocols/mod.rs
@@ -94,7 +94,10 @@ fn inner_get_discovery_handler(
             _ => Err(anyhow::format_err!("No protocol configured")),
         },
         #[allow(unreachable_patterns)]
-        config => Err(anyhow::format_err!("No handler found for configuration {:?}", config))
+        config => Err(anyhow::format_err!(
+            "No handler found for configuration {:?}",
+            config
+        )),
     }
 }
 

--- a/agent/src/protocols/mod.rs
+++ b/agent/src/protocols/mod.rs
@@ -93,6 +93,12 @@ fn inner_get_discovery_handler(
             Ok(_) => Ok(Box::new(debug_echo::DebugEchoDiscoveryHandler::new(dbg))),
             _ => Err(anyhow::format_err!("No protocol configured")),
         },
+        // If the feature-gated protocol handlers are not included, this catch-all
+        // should surface any invalid Configuration requests (i.e. udev-feat not 
+        // included at build-time ... but at runtime, a udev Configuration is
+        // applied).  For the default build, where all features are included, this
+        // code triggers an unreachable pattern warning.  #[allow] is added to
+        // explicitly hide this warning.
         #[allow(unreachable_patterns)]
         config => Err(anyhow::format_err!(
             "No handler found for configuration {:?}",

--- a/agent/src/protocols/mod.rs
+++ b/agent/src/protocols/mod.rs
@@ -93,9 +93,8 @@ fn inner_get_discovery_handler(
             Ok(_) => Ok(Box::new(debug_echo::DebugEchoDiscoveryHandler::new(dbg))),
             _ => Err(anyhow::format_err!("No protocol configured")),
         },
-        config => {
-            panic!("No handler found for configuration {:?}", config);
-        }
+        #[allow(unreachable_patterns)]
+        config => Err(anyhow::format_err!("No handler found for configuration {:?}", config))
     }
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The catchall match is there in case someone turns off one of the handlers via features ... but at runtime the disabled feature is configured.  The build warning is annoying.

