### PR TITLE
Improve development experience with timestamped container labels [IGNORE INTERMEDIATE BUILDS] [SAME VERSION]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ DOCKERFILE_DIR ?= build/containers
 
 PREFIX ?= $(REGISTRY)/$(UNIQUE_ID)
 VERSION=$(shell cat version.txt)
-VERSION_LABEL=v$(VERSION)
+TIMESTAMP=$(shell date +"%Y%m%d_%H%M%S")
+VERSION_LABEL=v$(VERSION)-$(TIMESTAMP)
 LABEL_PREFIX ?= $(VERSION_LABEL)
 
 CACHE_OPTION ?=


### PR DESCRIPTION
**What this PR does / why we need it**:
Addressing issue: https://github.com/deislabs/akri/issues/136

Using labels based on version.txt can make it difficult to iterate during development.  Creating timestamped labels for the local build experience should make it easier to differentiate between development builds.

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)