### PR TITLE
Reduce frequency of dependency update [SAME VERSION]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://help.github.com/en/articles/about-code-owners#codeowners-syntax
 
-*   @bfjelds @kate-goldenring @jiria @britel
+*   @bfjelds @kate-goldenring @jiria @britel @romoh

--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -2,7 +2,7 @@ name: Dependencies autoupdate
 
 on:
   schedule:
-    - cron: '0 0 * * *' # run daily at 12:00 am
+    - cron: '0 0 * * 1' # run on first day of each month at 12:00 am
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -2,7 +2,7 @@ name: Dependencies autoupdate
 
 on:
   schedule:
-    - cron: '0 0 * * 1' # run on first day of each month at 12:00 am
+    - cron: '0 0 1 * *' # run on first day of each month at 12:00 am UTC time
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Our dependencies update on a daily basis ... not sure it makes sense for us to update our version each time someone else's do.  I chose a monthly cadence because it would, at most, cause us to update our version 12x per year, which doesn't seem too bad.