### PR TITLE
Lazy eval of makefile timestamp breaks local build [SAME VERSION] [IGNORE INTERMEDIATE BUILDS]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,12 @@ INTERMEDIATE_DOCKERFILE_DIR ?= build/containers/intermediate
 DOCKERFILE_DIR ?= build/containers
 
 PREFIX ?= $(REGISTRY)/$(UNIQUE_ID)
-VERSION=$(shell cat version.txt)
-TIMESTAMP=$(shell date +"%Y%m%d_%H%M%S")
+
+# Evaluate VERSION and TIMESTAMP immediately to avoid
+# any lazy evaluation change in the values
+VERSION := $(shell cat version.txt)
+TIMESTAMP := $(shell date +"%Y%m%d_%H%M%S")
+
 VERSION_LABEL=v$(VERSION)-$(TIMESTAMP)
 LABEL_PREFIX ?= $(VERSION_LABEL)
 


### PR DESCRIPTION
Evaluate timestamp and version immediately so the variables are consistent throughout a single make execution