### PR TITLE
Akri's logging conventions [SAME VERSION]

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -39,7 +39,7 @@ Akri follows similar logging conventions as defined by the [Tracing crate](https
 | warn  | Unexpected errors that may/may not lead to serious problems |
 | info  | Useful information that provides an overview of the current state of things (ex: config values, state change) |
 | debug | Verbose information for high-level debugging and diagnoses of issues |
-| trace | Extremely verbose information for developers of akri |
+| trace | Extremely verbose information for developers of Akri |
 
 ## PR title flags
 Akri's workflows check for three flags in the titles of PRs in order to decide whether to execute certain checks. 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,6 +31,16 @@ To ensure that all product versioning is consistent, our CI builds will execute 
 
 > Note for MacOS users: `version.sh` uses the GNU `sed` command under-the-hood, but MacOS has built-in its own version. We recommend installing the GNU version via `brew install gnu-sed`. Then follow the brew instructions on how to use the installed GNU `sed` instead of the MacOS one.
 
+## Logging
+Akri follows similar logging conventions as defined by the [Tracing crate](https://docs.rs/tracing/0.1.22/tracing/struct.Level.html). When adding logging to new code, follow the verbosity guidelines. 
+| verbosity |  when to use?  |
+|---|---|
+| error | Unrecoverable fatal errors |
+| warn  | Unexpected errors that may/may not lead to serious problems |
+| info  | Useful information that provides an overview of the current state of things (ex: config values, state change) |
+| debug | Verbose information for high-level debugging and diagnoses of issues |
+| trace | Extremely verbose information for developers of akri |
+
 ## PR title flags
 Akri's workflows check for three flags in the titles of PRs in order to decide whether to execute certain checks. 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Proposal for logging conventions in Akri and reflecting that in the documentations.

**Special notes for your reviewer**:
If agreed on proposed conventions, another round of edits can be done to update some of the existing logging statements (mostly from info to trace) to adhere to those guidelines.

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)