### PR TITLE
Allow dependencies-autoupdate workflow to be manually run [SAME VERSION]

### DIFF
--- a/.github/workflows/auto-update-dependencies.yml
+++ b/.github/workflows/auto-update-dependencies.yml
@@ -1,6 +1,7 @@
 name: Dependencies autoupdate
 
 on:
+  workflow_dispatch:    # can be manually run if needed
   schedule:
     - cron: '0 0 1 * *' # run on first day of each month at 12:00 am UTC time
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enabling the workflow to be manually runnable is handy in the event a cargo audit detects a vulnerability or the action needs to be re-run to pick new version update... etc.

**Special notes for your reviewer**:
N/A

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)