### PR TITLE
Move security audit checks to a daily schedule [SAME VERSION]

### DIFF
--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -24,11 +24,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/audit-check@v1
-        with:
-          # token is only used for creating the audit report and does not impact the 
-          # functionality or success/failure of the job in case the token is unavailable 
-          token: ${{ secrets.GITHUB_TOKEN }}
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -20,7 +20,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  security_audit:
+  rust_checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -20,10 +20,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  rust_checks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -30,7 +30,7 @@ jobs:
           password: ${{secrets.AKRI_BOT_PASSWORD}}
           subject: "Security vulnerability detected in ${{github.repository}}"
           body: |-
-            A security vulnerability was detected in one or more of Akri's. For more details, check the output of the [security audit workflow](https://github.com/${{github.repository}}/runs/actions)
+            A security vulnerability was detected in one or more of Akri's dependencies. For more details, check the output of the [security audit workflow](https://github.com/${{github.repository}}/runs/actions)
 
             Hint: In most cases, running the [auto-update dependencies](https://github.com/deislabs/akri/actions/workflows/auto-update-dependencies.yml) workflow will fix the issue.
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,42 @@
+# This is a security audit workflow that runs security audit checks and send an email in case any vulnerabilities are detected.
+
+name: Security Audit
+on:
+  schedule:
+  - cron: '0 0 * * *' #runs daily at 12:00 am UTC
+    
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run security audit check
+        id: cargo-audit
+        continue-on-error: true
+        uses: actions-rs/audit-check@v1
+        with:
+          # token is only used for creating the audit report and does not impact the 
+          # functionality or success/failure of the job in case the token is unavailable 
+          token: ${{ secrets.GITHUB_TOKEN }}
+  
+      # sends an email if security audit failed 
+      - name: Send mail
+        if: steps.cargo-audit.outcome != 'success'
+        uses: dawidd6/action-send-mail@v2
+        with:
+          server_address: smtp-mail.outlook.com
+          server_port: 587
+          username: ${{secrets.AKRI_BOT_EMAIL}}
+          password: ${{secrets.AKRI_BOT_PASSWORD}}
+          subject: "Security vulnerability detected in ${{github.repository}}"
+          body: |-
+            A security vulnerability was detected in one or more of Akri's. For more details, check the output of the [security audit workflow](https://github.com/${{github.repository}}/runs/actions)
+
+            Hint: In most cases, running the [auto-update dependencies](https://github.com/deislabs/akri/actions/workflows/auto-update-dependencies.yml) workflow will fix the issue.
+
+            -Your friendly Akri bot 🤖
+          to: ${{secrets.AKRI_TEAM_EMAIL}}
+          from: ${{secrets.AKRI_BOT_EMAIL}}
+          content_type: text/html
+          convert_markdown: true
+      

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -30,7 +30,7 @@ jobs:
           password: ${{secrets.AKRI_BOT_PASSWORD}}
           subject: "Security vulnerability detected in ${{github.repository}}"
           body: |-
-            A security vulnerability was detected in one or more of Akri's dependencies. For more details, check the output of the [security audit workflow](https://github.com/${{github.repository}}/runs/actions)
+            A security vulnerability was detected in one or more of Akri's dependencies. For more details, check the output of the [security audit workflow](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})
 
             Hint: In most cases, running the [auto-update dependencies](https://github.com/deislabs/akri/actions/workflows/auto-update-dependencies.yml) workflow will fix the issue.
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -22,7 +22,7 @@ jobs:
   
       # sends an email if security audit failed 
       - name: Send mail
-        if: steps.cargo-audit.outcome != 'success'
+        if: steps.cargo-audit.outcome != 'success' && github.repository == 'deislabs/akri' # only run on main repo and not forks
         uses: dawidd6/action-send-mail@v2
         with:
           server_address: smtp-mail.outlook.com

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run security audit check
         id: cargo-audit
+        if: github.repository == 'deislabs/akri' # only run on main repo and not forks
         continue-on-error: true
         uses: actions-rs/audit-check@v1
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of check-rust workflow, we also run `cargo audit` to detect any security vulnerabilities in Akri's dependencies. This was added to catch newly added dependencies imposing security risks to Akri. However, we ended up with those checks blocking PRs & code merges because of existing dependencies being out of date or a new vulnerability is discovered in a version of a crate that Akri is already consuming, so this check ended up being very noisy and hence this PR.

This change:
* Removes security audit checks from the 'check-rust'
* Creates a new workflow that runs daily that takes care of running the security audit and sends akri team an email in the event a security vulnerability was detected.

A v2 of this change would be to add another step in check-rust workflow to audit newly added dependencies. Another potential improvement is to attempt re-running the audit after a cargo update and in case that succeeds the workflow can kick off the autoupdate-dependencies workflow instead of sending an email to minimize manual intervention. 

Note: The audit github action will create an issue when a vulnerability is detected. I'm not very happy with that as that is not a recommended/secure approach. Usually in the event a security vulnerability is detected in some codebase, it is best to fix asap rather than documenting it through issues where others become aware of that and can leverage to compromise the code. I opened an [issue](https://github.com/actions-rs/audit-check/issues/180) on audit-check and will investigate other github action options.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)