### PR TITLE
Increase docker create timeout to 600 minutes and document this hidden timeout

### DIFF
--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -21,7 +21,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ fromJSON(env.TARPAULIN_TIMEOUT_MINUTES) }}
 
     steps:
     - name: Checkout the head commit of the branch
@@ -31,7 +30,7 @@ jobs:
 
     - name: Create tarpaulin instance
       run: |
-        STAY_ALIVE_SCRIPT="sleep ${{ env.TARPAULIN_TIMEOUT_MINUTES }}m; echo bye"
+        STAY_ALIVE_SCRIPT="sleep ${{ fromJSON(env.TARPAULIN_TIMEOUT_MINUTES) }}m; echo bye"
         echo "Using this as stay-alive script: [ $STAY_ALIVE_SCRIPT ]"
         docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo $STAY_ALIVE_SCRIPT > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
     - name: Start tarpaulin instance
@@ -44,7 +43,7 @@ jobs:
       run: docker exec $(cat container_id.txt) sh -c "rustup component add rustfmt"
     - name: Run tarpaulin
       id: run-coverage-tests
-      timeout-minutes: 30
+      timeout-minutes: ${{ fromJSON(env.TARPAULIN_TIMEOUT_MINUTES) }}
       run: docker exec $(cat container_id.txt) sh -c "RUST_LOG=trace cargo tarpaulin -v --all-features --out Xml"
 
     - name: Upload report to codecov for push

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -25,7 +25,7 @@ jobs:
     # but it seems easier to make it SOOOO big that timeout-minutes is likely to never be impacted by
     # by it.
     #
-    # But, if thiw workflow is mysteriously timing out after 600 minutes, make changes to the docker
+    # But, if this workflow is mysteriously timing out after 600 minutes, make changes to the docker
     # create command in the Create tarpaulin instance step.
     timeout-minutes: 30
 

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -30,7 +30,10 @@ jobs:
         persist-credentials: false
 
     - name: Create tarpaulin instance
-      run: docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo 'sleep ${{ env.TARPAULIN_TIMEOUT_MINUTES }}m; echo bye' > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
+      run: |
+        STAY_ALIVE_SCRIPT = "sleep ${{ env.TARPAULIN_TIMEOUT_MINUTES }}m; echo bye"
+        echo "Using this as stay-alive script: [ $STAY_ALIVE_SCRIPT ]"
+        docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo $STAY_ALIVE_SCRIPT > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
     - name: Start tarpaulin instance
       run: docker start $(cat container_id.txt)
     - name: Install linux requirement in tarpaulin instance

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -20,7 +20,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
 
     steps:
     - name: Checkout the head commit of the branch
@@ -30,16 +29,20 @@ jobs:
 
     - name: Create tarpaulin instance
       run: |
-        STAY_ALIVE_SCRIPT = "sleep ${{ jobs.build.timeout-minutes }}m; echo bye"
+        STAY_ALIVE_SCRIPT = "sleep ${{ steps.run-coverage-tests.timeout-minutes }}m; echo bye"
         echo "Using this as stay-alive script: [ $STAY_ALIVE_SCRIPT ]"
         docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo $STAY_ALIVE_SCRIPT > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
     - name: Start tarpaulin instance
       run: docker start $(cat container_id.txt)
     - name: Install linux requirement in tarpaulin instance
+      timeout-minutes: 5
       run: docker exec $(cat container_id.txt) sh -c "echo Run apt update and apt install the following dependencies - git curl libssl-dev pkg-config libudev-dev libv4l-dev ; apt update ; apt install -y git curl libssl-dev pkg-config libudev-dev libv4l-dev"
     - name: Install rust requirements in tarpaulin instance
+      timeout-minutes: 5
       run: docker exec $(cat container_id.txt) sh -c "rustup component add rustfmt"
     - name: Run tarpaulin
+      id: run-coverage-tests
+      timeout-minutes: 30
       run: docker exec $(cat container_id.txt) sh -c "RUST_LOG=trace cargo tarpaulin -v --all-features --out Xml"
 
     - name: Upload report to codecov for push

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -16,10 +16,12 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  TARPAULIN_TIMEOUT_MINUTES: 30
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: ${{ fromJSON(env.TARPAULIN_TIMEOUT_MINUTES) }}
 
     steps:
     - name: Checkout the head commit of the branch
@@ -29,7 +31,7 @@ jobs:
 
     - name: Create tarpaulin instance
       run: |
-        STAY_ALIVE_SCRIPT="sleep ${{ steps.run-coverage-tests.timeout-minutes }}m; echo bye"
+        STAY_ALIVE_SCRIPT="sleep ${{ env.TARPAULIN_TIMEOUT_MINUTES }}m; echo bye"
         echo "Using this as stay-alive script: [ $STAY_ALIVE_SCRIPT ]"
         docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo $STAY_ALIVE_SCRIPT > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
     - name: Start tarpaulin instance

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         STAY_ALIVE_SCRIPT="sleep ${{ fromJSON(env.TARPAULIN_TIMEOUT_MINUTES) }}m; echo bye"
         echo "Using this as stay-alive script: [ $STAY_ALIVE_SCRIPT ]"
-        docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo $STAY_ALIVE_SCRIPT > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
+        docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo ${STAY_ALIVE_SCRIPT} > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
     - name: Start tarpaulin instance
       run: docker start $(cat container_id.txt)
     - name: Install linux requirement in tarpaulin instance

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -16,7 +16,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  TARPAULIN_TIMEOUT_MINUTES: 30
 
 jobs:
   build:

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -23,7 +23,7 @@ jobs:
     # There is a second, hidden timeout in this workflow.  When the tarpaulin container is created,
     # it is created with a CMD that sleeps for 600 minutes.  A more reasonable value could be selected,
     # but it seems easier to make it SOOOO big that timeout-minutes is likely to never be impacted by
-    # by it.
+    # it.
     #
     # But, if this workflow is mysteriously timing out after 600 minutes, make changes to the docker
     # create command in the Create tarpaulin instance step.

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -16,11 +16,12 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  TARPAULIN_TIMEOUT_MINUTES: 30
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: ${{ env.TARPAULIN_TIMEOUT_MINUTES }}
 
     steps:
     - name: Checkout the head commit of the branch
@@ -29,7 +30,7 @@ jobs:
         persist-credentials: false
 
     - name: Create tarpaulin instance
-      run: docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo 'sleep 20m; echo bye' > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
+      run: docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo 'sleep ${{ env.TARPAULIN_TIMEOUT_MINUTES }}m; echo bye' > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
     - name: Start tarpaulin instance
       run: docker start $(cat container_id.txt)
     - name: Install linux requirement in tarpaulin instance

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Create tarpaulin instance
       run: |
-        STAY_ALIVE_SCRIPT = "sleep ${{ steps.run-coverage-tests.timeout-minutes }}m; echo bye"
+        STAY_ALIVE_SCRIPT="sleep ${{ steps.run-coverage-tests.timeout-minutes }}m; echo bye"
         echo "Using this as stay-alive script: [ $STAY_ALIVE_SCRIPT ]"
         docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo $STAY_ALIVE_SCRIPT > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
     - name: Start tarpaulin instance

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -21,6 +21,14 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # There is a second, hidden timeout in this workflow.  When the tarpaulin container is created,
+    # it is created with a CMD that sleeps for 600 minutes.  A more reasonable value could be selected,
+    # but it seems easier to make it SOOOO big that timeout-minutes is likely to never be impacted by
+    # by it.
+    #
+    # But, if thiw workflow is mysteriously timing out after 600 minutes, make changes to the docker
+    # create command in the Create tarpaulin instance step.
+    timeout-minutes: 30
 
     steps:
     - name: Checkout the head commit of the branch
@@ -29,21 +37,14 @@ jobs:
         persist-credentials: false
 
     - name: Create tarpaulin instance
-      run: |
-        STAY_ALIVE_SCRIPT="sleep ${{ fromJSON(env.TARPAULIN_TIMEOUT_MINUTES) }}m; echo bye"
-        echo "Using this as stay-alive script: [ $STAY_ALIVE_SCRIPT ]"
-        docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo ${STAY_ALIVE_SCRIPT} > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
+      run: docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo 'sleep 600m; echo bye' > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
     - name: Start tarpaulin instance
       run: docker start $(cat container_id.txt)
     - name: Install linux requirement in tarpaulin instance
-      timeout-minutes: 5
       run: docker exec $(cat container_id.txt) sh -c "echo Run apt update and apt install the following dependencies - git curl libssl-dev pkg-config libudev-dev libv4l-dev ; apt update ; apt install -y git curl libssl-dev pkg-config libudev-dev libv4l-dev"
     - name: Install rust requirements in tarpaulin instance
-      timeout-minutes: 5
       run: docker exec $(cat container_id.txt) sh -c "rustup component add rustfmt"
     - name: Run tarpaulin
-      id: run-coverage-tests
-      timeout-minutes: ${{ fromJSON(env.TARPAULIN_TIMEOUT_MINUTES) }}
       run: docker exec $(cat container_id.txt) sh -c "RUST_LOG=trace cargo tarpaulin -v --all-features --out Xml"
 
     - name: Upload report to codecov for push

--- a/.github/workflows/run-tarpaulin.yml
+++ b/.github/workflows/run-tarpaulin.yml
@@ -16,12 +16,11 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  TARPAULIN_TIMEOUT_MINUTES: 30
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: ${{ env.TARPAULIN_TIMEOUT_MINUTES }}
+    timeout-minutes: 30
 
     steps:
     - name: Checkout the head commit of the branch
@@ -31,7 +30,7 @@ jobs:
 
     - name: Create tarpaulin instance
       run: |
-        STAY_ALIVE_SCRIPT = "sleep ${{ env.TARPAULIN_TIMEOUT_MINUTES }}m; echo bye"
+        STAY_ALIVE_SCRIPT = "sleep ${{ jobs.build.timeout-minutes }}m; echo bye"
         echo "Using this as stay-alive script: [ $STAY_ALIVE_SCRIPT ]"
         docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo $STAY_ALIVE_SCRIPT > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
     - name: Start tarpaulin instance


### PR DESCRIPTION
The tarpaulin action has 2 timeouts ... one obvious, the action (`timeout-minutes`), one hidden (`sleep 20m`):

```yaml
run: docker create --network host --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin:0.16.0 bash -c "echo 'sleep 20m; echo bye' > /tmp/keep_alive.sh; chmod 777 /tmp/keep_alive.sh; /tmp/keep_alive.sh" > container_id.txt
```

The reason for the second is to keep the tarpaulin container instance alive while executing the unit tests.

IDEAL: Attempt to use a single env var to dictate both settings.

Unfortunately, the ideal is not working for me.  It is possible to create an env var for the timeout and reference it from a step's timeout (not a job's for some reason): https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#job-context ... but, I can't seem to reference that variable from the `docker create` command.

So, resorting to setting the docker create timeout to something really big (600 minutes)

