### PR TITLE
Try to ONLY build rust once per platform

### DIFF
--- a/.github/workflows/build-agent-container.yml
+++ b/.github/workflows/build-agent-container.yml
@@ -1,35 +1,10 @@
 name: Build Agent
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-agent-container.yml
-    - build/containers/Dockerfile.agent
-    - agent/**
-    - shared/**
-    - version.txt
-    - build/akri-containers.mk
-    - build/akri-rust-containers.mk
-    - Makefile
-  pull_request:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-agent-container.yml
-    - build/containers/Dockerfile.agent
-    - agent/**
-    - shared/**
-    - version.txt
-    - build/akri-containers.mk
-    - build/akri-rust-containers.mk
-    - Makefile
-  release:
-    types:
-      - published
+  workflow_run:
+    workflows: ["Build Production Rust Code"]
+    types: 
+      - completed
 
 env:
   AKRI_COMPONENT: agent
@@ -62,13 +37,24 @@ jobs:
         yarn install
         yarn add @actions/core @actions/github @actions/exec fs
 
+    - name: Download rust build artifacts
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        workflow_conclusion: success
+        commit: ${{ github.event.workflow_run.head_sha }}
+        name: rust-${{ matrix.arch.label }}-binaries
+        path: /tmp
+
+    - name: Unpack Rust binaries
+      run: |
+        tar -xvf /tmp/rust-${{ matrix.arch.label }}-binaries.tar
+
     - name: Run Per-Arch component build for ${{ env.AKRI_COMPONENT }}
       uses: ./.github/actions/build-component-per-arch
       with:
-        github_event_name: ${{ github.event_name }}
+        github_event_name: ${{ github.event.workflow_run.event }}
         github_ref: ${{ github.ref }}
-        github_event_action: ${{ github.event.action }}
-        github_merged: ${{ github.event.pull_request.merged }}
         container_name: ${{ env.AKRI_COMPONENT }}
         container_prefix: ghcr.io/deislabs/akri
         container_registry_base_url: ghcr.io
@@ -76,10 +62,10 @@ jobs:
         container_registry_password: ${{ secrets.crPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}
-        build_rust: "1"
+        build_rust: "0"
 
   multi-arch:
-    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+    if: (github.event.workflow_run.event == 'release') || (github.event.workflow_run.event == 'push' && github.ref == 'refs/heads/main')
     needs: per-arch
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -102,7 +88,7 @@ jobs:
     - name: Run Multi-Arch component build for ${{ env.AKRI_COMPONENT }}
       uses: ./.github/actions/build-component-multi-arch
       with:
-        github_event_name: ${{ github.event_name }}
+        github_event_name: ${{ github.event.workflow_run.event }}
         container_name: ${{ env.AKRI_COMPONENT }}
         container_prefix: ghcr.io/deislabs/akri
         container_registry_base_url: ghcr.io

--- a/.github/workflows/build-controller-container.yml
+++ b/.github/workflows/build-controller-container.yml
@@ -1,35 +1,10 @@
 name: Build Controller
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-controller-container.yml
-    - build/containers/Dockerfile.controller
-    - controller/**
-    - shared/**
-    - version.txt
-    - build/akri-containers.mk
-    - build/akri-rust-containers.mk
-    - Makefile
-  pull_request:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-controller-container.yml
-    - build/containers/Dockerfile.controller
-    - controller/**
-    - shared/**
-    - version.txt
-    - build/akri-containers.mk
-    - build/akri-rust-containers.mk
-    - Makefile
-  release:
-    types:
-      - published
+  workflow_run:
+    workflows: ["Build Production Rust Code"]
+    types: 
+      - completed
 
 env:
   AKRI_COMPONENT: controller
@@ -61,13 +36,24 @@ jobs:
         yarn install
         yarn add @actions/core @actions/github @actions/exec fs
 
+    - name: Download rust build artifacts
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        workflow_conclusion: success
+        commit: ${{ github.event.workflow_run.head_sha }}
+        name: rust-${{ matrix.arch.label }}-binaries
+        path: /tmp
+
+    - name: Unpack Rust binaries
+      run: |
+        tar -xvf /tmp/rust-${{ matrix.arch.label }}-binaries.tar
+
     - name: Run Per-Arch component build for ${{ env.AKRI_COMPONENT }}
       uses: ./.github/actions/build-component-per-arch
       with:
-        github_event_name: ${{ github.event_name }}
+        github_event_name: ${{ github.event.workflow_run.event }}
         github_ref: ${{ github.ref }}
-        github_event_action: ${{ github.event.action }}
-        github_merged: ${{ github.event.pull_request.merged }}
         container_name: ${{ env.AKRI_COMPONENT }}
         container_prefix: ghcr.io/deislabs/akri
         container_registry_base_url: ghcr.io
@@ -75,10 +61,10 @@ jobs:
         container_registry_password: ${{ secrets.crPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}
-        build_rust: "1"
+        build_rust: "0"
 
   multi-arch:
-    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+    if: (github.event.workflow_run.event == 'release') || (github.event.workflow_run.event == 'push' && github.ref == 'refs/heads/main')
     needs: per-arch
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -101,7 +87,7 @@ jobs:
     - name: Run Multi-Arch component build for ${{ env.AKRI_COMPONENT }}
       uses: ./.github/actions/build-component-multi-arch
       with:
-        github_event_name: ${{ github.event_name }}
+        github_event_name: ${{ github.event.workflow_run.event }}
         container_name: ${{ env.AKRI_COMPONENT }}
         container_prefix: ghcr.io/deislabs/akri
         container_registry_base_url: ghcr.io

--- a/.github/workflows/build-opcua-monitoring-broker-container.yml
+++ b/.github/workflows/build-opcua-monitoring-broker-container.yml
@@ -74,7 +74,7 @@ jobs:
         container_registry_password: ${{ secrets.crPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}
-        build_rust: "1"
+        build_rust: "0"
 
   multi-arch:
     if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')

--- a/.github/workflows/build-rust-code.yml
+++ b/.github/workflows/build-rust-code.yml
@@ -1,0 +1,90 @@
+name: Build Production Rust Code
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - .github/actions/build-component-per-arch/**
+    - .github/actions/build-component-multi-arch/**
+    - .github/workflows/build-agent-container.yml
+    - .github/workflows/build-controller-container.yml
+    - .github/workflows/build-udev-video-broker-container.yml
+    - .github/workflows/build-webhook-configuration-container.yml
+    - build/containers/Dockerfile.agent
+    - build/containers/Dockerfile.controller
+    - build/containers/Dockerfile.udev-video-broker
+    - build/containers/Dockerfile.webhook-configuration
+    - '**.rs'
+    - '**/Cargo.toml'
+    - '**/Cargo.lock'
+    - version.txt
+    - build/akri-containers.mk
+    - build/akri-rust-containers.mk
+    - Makefile
+  pull_request:
+    branches: [ main ]
+    paths:
+    - .github/actions/build-component-per-arch/**
+    - .github/actions/build-component-multi-arch/**
+    - .github/workflows/build-agent-container.yml
+    - .github/workflows/build-controller-container.yml
+    - .github/workflows/build-udev-video-broker-container.yml
+    - .github/workflows/build-webhook-configuration-container.yml
+    - build/containers/Dockerfile.agent
+    - build/containers/Dockerfile.controller
+    - build/containers/Dockerfile.udev-video-broker
+    - build/containers/Dockerfile.webhook-configuration
+    - '**.rs'
+    - '**/Cargo.toml'
+    - '**/Cargo.lock'
+    - version.txt
+    - build/akri-containers.mk
+    - build/akri-rust-containers.mk
+    - Makefile
+  release:
+    types:
+      - published
+
+jobs:
+
+  build-rust:
+    runs-on: ubuntu-latest
+    timeout: 40
+    strategy:
+      matrix:
+        arch:
+          - label: arm64v8
+            make-target: arm64
+            rust-target-path: aarch64-unknown-linux-gnu
+          - label: arm32v7
+            make-target: arm32
+            rust-target-path: armv7-unknown-linux-gnueabihf
+          - label: amd64
+            make-target: amd64
+            rust-target-path: x86_64-unknown-linux-gnu
+    
+    steps:
+    - name: Checkout the head commit of the branch
+      uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+
+    - name: Build production rust for ${{ matrix.arch.label }}
+      run: |
+        make install-cross
+        cross --version
+        make akri-cross-build-${{ matrix.arch.make-target }}
+
+    - name: Package build binaries
+      run: |
+        tar_manifest='/tmp/tar-contents.txt'
+        > $tar_manifest
+        for f in target/${{ matrix.arch.rust-target-path }}/release/*; do filetype=$( file "$f" ); case "$filetype" in *ELF*) echo "$f" >> $tar_manifest ;; esac; done
+        tar -cvf /tmp/rust-${{ matrix.arch.label }}-binaries.tar `cat $tar_manifest`
+
+    - name: Upload target binaries as artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: rust-${{ matrix.arch.label }}-binaries
+        path: /tmp/rust-${{ matrix.arch.label }}-binaries.tar
+

--- a/.github/workflows/build-udev-video-broker-container.yml
+++ b/.github/workflows/build-udev-video-broker-container.yml
@@ -1,35 +1,10 @@
 name: Build UDEV Broker
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-udev-video-broker-container.yml
-    - build/containers/Dockerfile.udev-video-broker
-    - samples/brokers/udev-video-broker/**
-    - shared/**
-    - version.txt
-    - build/akri-containers.mk
-    - build/akri-rust-containers.mk
-    - Makefile
-  pull_request:
-    branches: [ main ]
-    paths:
-    - .github/actions/build-component-per-arch/**
-    - .github/actions/build-component-multi-arch/**
-    - .github/workflows/build-udev-video-broker-container.yml
-    - build/containers/Dockerfile.udev-video-broker
-    - samples/brokers/udev-video-broker/**
-    - shared/**
-    - version.txt
-    - build/akri-containers.mk
-    - build/akri-rust-containers.mk
-    - Makefile
-  release:
-    types:
-      - published
+  workflow_run:
+    workflows: ["Build Production Rust Code"]
+    types: 
+      - completed
 
 env:
   AKRI_COMPONENT: udev-video-broker
@@ -62,13 +37,24 @@ jobs:
         yarn install
         yarn add @actions/core @actions/github @actions/exec fs
 
+    - name: Download rust build artifacts
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        workflow_conclusion: success
+        commit: ${{ github.event.workflow_run.head_sha }}
+        name: rust-${{ matrix.arch.label }}-binaries
+        path: /tmp
+
+    - name: Unpack Rust binaries
+      run: |
+        tar -xvf /tmp/rust-${{ matrix.arch.label }}-binaries.tar
+
     - name: Run Per-Arch component build for ${{ env.AKRI_COMPONENT }}
       uses: ./.github/actions/build-component-per-arch
       with:
-        github_event_name: ${{ github.event_name }}
+        github_event_name: ${{ github.event.workflow_run.event }}
         github_ref: ${{ github.ref }}
-        github_event_action: ${{ github.event.action }}
-        github_merged: ${{ github.event.pull_request.merged }}
         container_name: ${{ env.AKRI_COMPONENT }}
         container_prefix: ghcr.io/deislabs/akri
         container_registry_base_url: ghcr.io
@@ -76,10 +62,10 @@ jobs:
         container_registry_password: ${{ secrets.crPassword }}
         makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
         platform: ${{ matrix.arch }}
-        build_rust: "1"
+        build_rust: "0"
 
   multi-arch:
-    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+    if: (github.event.workflow_run.event == 'release') || (github.event.workflow_run.event == 'push' && github.ref == 'refs/heads/main')
     needs: per-arch
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -102,7 +88,7 @@ jobs:
     - name: Run Multi-Arch component build for ${{ env.AKRI_COMPONENT }}
       uses: ./.github/actions/build-component-multi-arch
       with:
-        github_event_name: ${{ github.event_name }}
+        github_event_name: ${{ github.event.workflow_run.event }}
         container_name: ${{ env.AKRI_COMPONENT }}
         container_prefix: ghcr.io/deislabs/akri
         container_registry_base_url: ghcr.io

--- a/.github/workflows/build-webhook-configuration-container.yml
+++ b/.github/workflows/build-webhook-configuration-container.yml
@@ -1,35 +1,10 @@
 name: Build Webhook Configuration
 
 on:
-  workflow_dispatch:
-    inputs:
-  push:
-    branches: [main]
-    paths:
-      - .github/actions/build-component-per-arch/**
-      - .github/actions/build-component-multi-arch/**
-      - .github/workflows/build-webhook-configuration-container.yml
-      - build/containers/Dockerfile.webhook-configuration
-      - webhooks/validating/configuration
-      - version.txt
-      - build/akri-containers.mk
-      - build/akri-rust-containers.mk
-      - Makefile
-  pull_request:
-    branches: [main]
-    paths:
-      - .github/actions/build-component-per-arch/**
-      - .github/actions/build-component-multi-arch/**
-      - .github/workflows/build-workflow-configuration-container.yml
-      - build/containers/Dockerfile.workflow-configuration
-      - webhooks/validating/configuration
-      - version.txt
-      - build/akri-containers.mk
-      - build/akri-rust-containers.mk
-      - Makefile
-  release:
-    types:
-      - published
+  workflow_run:
+    workflows: ["Build Production Rust Code"]
+    types: 
+      - completed
 
 env:
   AKRI_COMPONENT: webhook-configuration
@@ -61,13 +36,24 @@ jobs:
           yarn install
           yarn add @actions/core @actions/github @actions/exec fs
 
+      - name: Download rust build artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          workflow_conclusion: success
+          commit: ${{ github.event.workflow_run.head_sha }}
+          name: rust-${{ matrix.arch.label }}-binaries
+          path: /tmp
+
+      - name: Unpack Rust binaries
+        run: |
+          tar -xvf /tmp/rust-${{ matrix.arch.label }}-binaries.tar
+
       - name: Run Per-Arch component build for ${{ env.AKRI_COMPONENT }}
         uses: ./.github/actions/build-component-per-arch
         with:
-          github_event_name: ${{ github.event_name }}
+          github_event_name: ${{ github.event.workflow_run.event }}
           github_ref: ${{ github.ref }}
-          github_event_action: ${{ github.event.action }}
-          github_merged: ${{ github.event.pull_request.merged }}
           container_name: ${{ env.AKRI_COMPONENT }}
           container_prefix: ghcr.io/deislabs/akri
           container_registry_base_url: ghcr.io
@@ -75,10 +61,10 @@ jobs:
           container_registry_password: ${{ secrets.crPassword }}
           makefile_component_name: ${{ env.MAKEFILE_COMPONENT }}
           platform: ${{ matrix.arch }}
-          build_rust: "1"
+          build_rust: "0"
 
   multi-arch:
-    if: (github.event_name == 'release') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (startsWith(github.event_name, 'pull_request') && github.event.action == 'closed' && github.event.pull_request.merged == true && github.ref != 'refs/heads/main')
+    if: (github.event.workflow_run.event == 'release') || (github.event.workflow_run.event == 'push' && github.ref == 'refs/heads/main')
     needs: per-arch
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -99,7 +85,7 @@ jobs:
       - name: Run Multi-Arch component build for ${{ env.AKRI_COMPONENT }}
         uses: ./.github/actions/build-component-multi-arch
         with:
-          github_event_name: ${{ github.event_name }}
+          github_event_name: ${{ github.event.workflow_run.event }}
           container_name: ${{ env.AKRI_COMPONENT }}
           container_prefix: ghcr.io/deislabs/akri
           container_registry_base_url: ghcr.io


### PR DESCRIPTION
**What this PR does / why we need it**:
We currently have 4 rust containers.  Each of them build for 3 different platforms.  For each container-platform combination (12), we build ALL of the rust binaries.  If each build is 30 minutes, we are using 360 minutes of github action time when we only need 90 minutes.

This isn't super-impactful because the workflows run at the same time.  But it is wasteful.  And if we increase our platforms (by adding windows, etc) or our containers (highly likely), this number could really explode.

To address this:
1. I created a `build the rust code` workflow which runs for all of the platforms and exports the executable files in the applicable target/<platform>/release folder as a tar in an artifact.
2. I made the rust container build workflows triggered by the `build the rust code` workflow and had them download and expand the appropriate artifact tar

> Note: there is no supported way to download another workflow's artifacts, so this makes use of someone's attempt to enable this

I don't know if this will work.

Also, this PR probably needs to be made as a branch PR (rather than a fork PR).

