### PR TITLE
Enable Canceling Previous Workflows on PRs from Forks [SAME VERSION]

### DIFF
--- a/.github/workflows/cancel-previous-pr-workflows.yml
+++ b/.github/workflows/cancel-previous-pr-workflows.yml
@@ -1,11 +1,14 @@
 name: Cancel Previous PR Workflows
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_run:
+    workflows: ["Dependencies autoupdate", "Build Agents", "Build Anomaly Detection App Container", "Build Controller", "Build ONVIF Broker (.NET)", "Build OPC UA Monitoring Broker", "Build OpenCV Base", "Build Production Rust Code", "Build Rust CrossBuild", "Build UDEV Broker", "Build Video Streaming App Container", "Build Webhook Configuration", "Check Rust", "Check versioning", "Helm", "Tarpaulin Code Coverage", "Test K3s, Kubernetes, and MicroK8s"]
+    types:
+      - requested
 jobs:
   cancel:
     runs-on: ubuntu-latest
+    if: (github.event.workflow_run.event != 'release') && (github.event.workflow_run.event != 'push')
     steps:
     - uses: styfle/cancel-workflow-action@0.8.0
       with:
-        workflow_id: "auto-update-dependencies.yml, build-agent-container.yml, build-anomaly-detection-app-container.yml, build-controller-container.yml, build-onvif-video-broker-container.yml, build-opcua-monitoring-broker-container.yml, build-opencv-base-container.yml, build-rust-code.yml, build-rust-crossbuild-container.yml, build-udev-video-broker-container.yml, build-video-streaming-app-container.yml, build-webhook-configuration-container.yml, check-rust.yml, check-versioning.yml, run-helm.yml, run-tarpaulin.yml, run-test-cases.yml"
+        workflow_id: ${{ github.event.workflow.id }}

--- a/.github/workflows/cancel-previous-pr-workflows.yml
+++ b/.github/workflows/cancel-previous-pr-workflows.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   cancel:
     runs-on: ubuntu-latest
-    if: (github.event.workflow_run.event != 'release') && (github.event.workflow_run.event != 'push')
+    if: github.event.workflow_run.event == 'pull_request'
     steps:
     - uses: styfle/cancel-workflow-action@0.8.0
       with:


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Our cancel workflow previously only worked on PRs not PRs from forks. Using `workflow_run` enables it to cancel previous workflows on PRs from forks. 
Added conditions so it does not cancel workflows on main or from releases.
