### PR TITLE
Specify component name in Agent multi-arch build [SAME VERSION]

### DIFF
--- a/.github/workflows/build-agent-container.yml
+++ b/.github/workflows/build-agent-container.yml
@@ -70,6 +70,11 @@ jobs:
     needs: per-arch
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        akri-component: 
+          - agent
+          - agent-full
 
     steps:
     - name: Checkout repo


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
The Agent component name is not being specified in the Agent Builds workflow for the multi-arch build. This adds a matrix with the component names.