### PR TITLE
Increase e2e test timeout [SAME VERSION]

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -98,7 +98,7 @@ jobs:
   test-cases:
     needs: build-containers
     runs-on: ubuntu-18.04
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -98,7 +98,7 @@ jobs:
   test-cases:
     needs: build-containers
     runs-on: ubuntu-18.04
-    timeout-minutes: 35
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
On pushes to main, the e2e tests waits 25 minutes for containers to build before starting. They then have 10 minutes to complete. This doesn't seem to be sufficient. Adding 10 minutes more.
