### PR TITLE
Use unshared debug echo in e2e tests [SAME VERSION]

### DIFF
--- a/test/run-end-to-end.py
+++ b/test/run-end-to-end.py
@@ -31,7 +31,7 @@ def main():
     print("Providing Akri Helm chart with CRI args: {}".format(cri_args))
     extra_helm_args = shared_test_code.get_extra_helm_args()
     print("Providing Akri Helm chart with extra helm args: {}".format(extra_helm_args))
-    helm_install_command = "helm install akri {} --set agent.full=true --set debugEcho.configuration.enabled=true --set debugEcho.configuration.name={} --set agent.allowDebugEcho=true {} {} --debug ".format(helm_chart_location, shared_test_code.DEBUG_ECHO_NAME, cri_args, extra_helm_args)
+    helm_install_command = "helm install akri {} --set agent.full=true --set debugEcho.configuration.enabled=true --set debugEcho.configuration.shared=false --set debugEcho.configuration.name={} --set agent.allowDebugEcho=true {} {} --debug ".format(helm_chart_location, shared_test_code.DEBUG_ECHO_NAME, cri_args, extra_helm_args)
     print("Helm command: {}".format(helm_install_command))
     os.system(helm_install_command)
     


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Before our latest DH changes, we used the debug echo Configuration in our e2e test to discover **unshared** devices ([past state](https://github.com/deislabs/akri/blob/5924ff72219fd9eb91b835e81c1115d04a533ef4/test/run-end-to-end.py#L34)). Currently we are discovering shared devices in e2e which is leading to a 5 min delay before devices are marked offline. This will speed up our tests and revert back to the previous pattern.

If we want to do shared, than we should change the test to one 5 minute sleep instead of checks every 20 seconds. 
