### PR TITLE
Add documentation on setting a Configuration's `brokerProperties`

### DIFF
--- a/docs/broker-development.md
+++ b/docs/broker-development.md
@@ -75,3 +75,22 @@ helm install akri akri-helm-charts/akri-dev \
     --set udev.configuration.brokerPod.image.repository="ghcr.io/brokers/camera-broker" \
     --set udev.configuration.brokerPod.image.tag="v0.0.1" 
 ```
+
+## Specifying additional broker environment variables in a Configuration
+You can request that additional environment variables are set in Pods that request devices discovered via an Akri
+Configuration. These are set as key/value pairs in a Configuration's `brokerProperties`. For example, take the scenario
+of brokers being deployed to USB cameras discovered by Akri. You may wish to give the brokers extra image about the
+image format and resolution the cameras support. The brokers then can look up these variables to know how to properly
+utilize their camera. These `brokerProperties` could be set in a Configuration during a Helm installation as follows:
+```sh
+  helm repo add akri-helm-charts https://deislabs.github.io/akri/
+  helm install akri akri-helm-charts/akri-dev \
+  --set udev.discovery.enabled=true \
+  --set udev.configuration.enabled=true \
+  --set udev.configuration.name=akri-udev-video \
+  --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"' \
+  --set udev.configuration.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker" \
+  --set udev.configuration.brokerProperties.FORMAT='JPEG' \
+  --set udev.configuration.brokerProperties.RESOLUTION_WIDTH='1000' \
+  --set udev.configuration.brokerProperties.RESOLUTION_HEIGHT='800'
+```

--- a/docs/broker-development.md
+++ b/docs/broker-development.md
@@ -79,7 +79,7 @@ helm install akri akri-helm-charts/akri-dev \
 ## Specifying additional broker environment variables in a Configuration
 You can request that additional environment variables are set in Pods that request devices discovered via an Akri
 Configuration. These are set as key/value pairs in a Configuration's `brokerProperties`. For example, take the scenario
-of brokers being deployed to USB cameras discovered by Akri. You may wish to give the brokers extra image about the
+of brokers being deployed to USB cameras discovered by Akri. You may wish to give the brokers extra information about the
 image format and resolution the cameras support. The brokers then can look up these variables to know how to properly
 utilize their camera. These `brokerProperties` could be set in a Configuration during a Helm installation as follows:
 ```sh

--- a/docs/end-to-end-demo.md
+++ b/docs/end-to-end-demo.md
@@ -184,7 +184,7 @@ Look at the Configuration and Instances in more detail.
     ```
 
 ## Going beyond the demo
-1. Plug in real cameras! You can [pass environment variables](./udev-video-sample.md#modifying-the-brokerpod-spec) to the frame server broker to specify the format, resolution width/height, and frames per second of your cameras.
+1. Plug in real cameras! You can [pass environment variables](./broker-development#Specifying-additional-broker-environment-variables-in-a-Configuration) to the frame server broker to specify the format, resolution width/height, and frames per second of your cameras.
 1. Apply the [ONVIF Configuration](onvif-configuration.md) and make the streaming app display footage from both the local video devices and onvif cameras. To do this, modify the [video streaming yaml](../deployment/samples/akri-video-streaming-app.yaml) as described in the inline comments in order to create a larger service that aggregates the output from both the `udev-camera-svc` service and `onvif-camera-svc` service.
 1. Add more nodes to the cluster.
 1. [Modify the udev rule](udev-video-sample.md#modifying-the-udev-rule) to find a more specific subset of cameras.

--- a/docs/udev-video-sample.md
+++ b/docs/udev-video-sample.md
@@ -1,17 +1,18 @@
 # Using the Udev Discovery Protocol to Discover USB Cameras
-As an example of handling local capabilities, a sample broker and streaming app have been made for utilizing video cameras discovered by Akri's udev protocol. To create an Akri Configuration to discover other devices via udev, see the [udev Configuration documentation](./udev-configuration.md). 
+As an example of handling local capabilities, a sample broker and streaming app have been made for utilizing video cameras discovered by Akri's udev Discovery Handler. To create an Akri Configuration to discover other devices via udev, see the [udev Configuration documentation](./udev-configuration.md). 
 
 Udev is a device manager for the Linux kernel. The udev discovery handler parses udev rules listed in a Configuration, searches for them using udev, and returns a list of device nodes (ie: /dev/video0). An instance is created for each device node. Since this example uses a [sample broker](../samples/brokers/udev-video-broker) that streams frames from a local camera, the rule added to the Configuration is `KERNEL=="video[0-9]*"`. To determine if a node has video devices that will be discovered by this Configuration, run `ls -l /sys/class/video4linux/` or `sudo v4l2-ctl --list-devices`. 
 
 ## Usage
-To use create a udev Configuration for video devices for your cluster, you can simply set `udev.enabled=true` and a udev rule of `--set udev.udevRules[0]='KERNEL==\"video[0-9]*\"'` when installing the Akri Helm chart. Optionally, set a name for your generated Configuration by setting `--set udev.name=akri-udev-video` and add a broker image in the case you want a workload automatically deployed to discovered devices. More information about the Akri Helm charts can be found in the [user guide](./user-guide.md#understanding-akri-helm-charts).
+To use create a udev Configuration for video devices for your cluster, you can simply set `udev.configuration.enabled=true` and a udev rule of `--set udev.configuration.udevRules[0]='KERNEL==\"video[0-9]*\"'` when installing the Akri Helm chart. Also enable udev discovery via `udev.discovery.enabled=true`. Optionally, set a name for your generated Configuration by setting `udev.configuraion.name=akri-udev-video` and add a broker image in the case you want Pods automatically deployed to discovered devices. More information about the Akri Helm charts can be found in the [user guide](./user-guide.md#understanding-akri-helm-charts).
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri-dev \
-    --set udev.enabled=true \
-    --set udev.name=akri-udev-video \
-    --set udev.udevRules[0]='KERNEL=="video[0-9]*"' \
-    --set udev.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker"
+    --set udev.discovery.enabled=true \
+    --set udev.configuration.enabled=true \
+    --set udev.configuration.name=akri-udev-video \
+    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"' \
+    --set udev.configuration.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker" 
 ```
 
 Akri will find all video4linux cameras and ensure that broker Pods are running on nodes that can access the cameras at all times, supplying each Instance Service and the Configuration Service with frames.
@@ -29,32 +30,39 @@ For example, the rule can be narrowed by matching cameras with specific properti
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri-dev \
-    --set udev.enabled=true \
-    --set udev.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_VENDOR}=="Microsoft"' \
-    --set udev.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker"
+    --set udev.discovery.enabled=true \
+    --set udev.configuration.enabled=true \
+    --set udev.configuration.name=akri-udev-video \
+    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_VENDOR}=="Microsoft"' \
+    --set udev.configuration.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker" 
 ```
 
 As another example, to make sure that the camera has a capture capability rather than just being a video output device, modify the udev rule as follows: 
 ```bash
 helm repo add akri-helm-charts https://deislabs.github.io/akri/
 helm install akri akri-helm-charts/akri-dev \
-    --set udev.enabled=true \
-    --set udev.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}=="*:capture:*"' \
-    --set udev.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker"
+    --set udev.discovery.enabled=true \
+    --set udev.configuration.enabled=true \
+    --set udev.configuration.name=akri-udev-video \
+    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"\, ENV{ID_V4L_CAPABILITIES}=="*:capture:*"' \
+    --set udev.configuration.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker" 
 ```
 
-### Modifying the brokerPod spec
-The `brokerPodSpec` property is a full [PodSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) and can be modified as such.  For example, to configure the frame rate, resolution, and image type the broker streams from the discovered video cameras, environment variables can be modified in the podspec. To examine what settings are supported by a camera, install `v4l-utils` and run `sudo v4l2-ctl -d /dev/video0 --list-formats-ext` on the node. By default, the environment variables are set to MJPG format, 640x480 resolution, and 10 frames per second. If the broker sees that those settings are not supported by the camera, it will query the v4l device for supported settings and use the first format, resolution, and fps in the lists returned. The environment variables can be changed when installing the Akri Helm chart. For example, tell the broker to stream JPEG format, 1000x800 resolution, and 30 frames per second by setting those environment variables when installing Akri.
+### Modifying the broker PodSpec
+The `brokerPodSpec` property is a full [PodSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) and can be modified as such.  For example, to configure the frame rate, resolution, and image type the broker streams from the discovered video cameras, environment variables can be modified in the PodSpec. To examine what settings are supported by a camera, install `v4l-utils` and run `sudo v4l2-ctl -d /dev/video0 --list-formats-ext` on the node. By default, the environment variables are set to MJPG format, 640x480 resolution, and 10 frames per second. If the broker sees that those settings are not supported by the camera, it will query the v4l device for supported settings and use the first format, resolution, and fps in the lists returned. The environment variables can be changed when installing the Akri Helm chart. For example, tell the broker to stream JPEG format, 1000x800 resolution, and 30 frames per second by setting those environment variables when installing Akri.
 ```bash
   helm install akri akri-helm-charts/akri-dev \
-    --set udev.enabled=true \
-    --set udev.udevRules[0]='KERNEL=="video[0-9]*"' \
-    --set udev.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker" \
-    --set udev.brokerPod.env.FORMAT='JPEG' \
-    --set udev.brokerPod.env.RESOLUTION_WIDTH='1000' \
-    --set udev.brokerPod.env.RESOLUTION_HEIGHT='800' \
-    --set udev.brokerPod.env.FRAMES_PER_SECOND='30'
+    --set udev.discovery.enabled=true \
+    --set udev.configuration.enabled=true \
+    --set udev.configuration.name=akri-udev-video \
+    --set udev.configuration.discoveryDetails.udevRules[0]='KERNEL=="video[0-9]*"' \
+    --set udev.configuration.brokerPod.image.repository="ghcr.io/deislabs/akri/udev-video-broker" \
+    --set udev.configuration.brokerPod.env.FORMAT='JPEG' \
+    --set udev.configuration.brokerPod.env.RESOLUTION_WIDTH='1000' \
+    --set udev.configuration.brokerPod.env.RESOLUTION_HEIGHT='800' \
+    --set udev.configuration.brokerPod.env.FRAMES_PER_SECOND='30'
 ```
+Instead of just setting these environment variables in the broker Pods automatically deployed by Akri, you can ensure that all Pods that request resources discovered via a Configuration have certain environment variables by [setting them in a Configuration's `brokerProperties`](./broker-development#Specifying-additional-broker-environment-variables-in-a-Configuration).
 
 **Note:** The udev video broker pods run privileged in order to access the video devices. More explicit device access
    could have been configured by setting the appropriate [security


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Previously, we had documentation on setting broker Pod environment variables via a Configuration's broker PodSpec. The convention now is to use a Configurations `brokerProperties` for setting env vars in Pods that request akri resources, whether the Pods are deployed by the Akri Controller (with a specified broker PodSpec) or manually.

Also the `udev-video-sample.md` document is a bit redundant to the end to end demo doc and `udev-configuration.md` doc and should potentially be removed. 