### PR TITLE
Use sudo when getting logs in e2e tests [SAME VERSION]

### DIFF
--- a/test/shared_test_code.py
+++ b/test/shared_test_code.py
@@ -91,11 +91,11 @@ def get_test_version():
 
 def save_agent_and_controller_logs(namespace="default"):
     kubectl_cmd = get_kubectl_command()
-    os.system("{} logs {} --namespace={} >> {}".format(kubectl_cmd,
+    os.system("sudo {} logs {} --namespace={} >> {}".format(kubectl_cmd,
                                                        agent_pod_name,
                                                        namespace,
                                                        AGENT_LOG_PATH))
-    os.system("{} logs {} --namespace={} >> {}".format(kubectl_cmd,
+    os.system("sudo {} logs {} --namespace={} >> {}".format(kubectl_cmd,
                                                        controller_pod_name,
                                                        namespace,
                                                        CONTROLLER_LOG_PATH))


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
MicroK8s requires privileged access to logs. As a result, our e2e tests have not been producing any logs on MicroK8s.