### PR TITLE
Reduce K3s and MicroK8s eviction limits for tests [SAME VERSION]

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -261,7 +261,7 @@ jobs:
           sudo sh -c "microk8s.kubectl config view --raw >~/.kube/config"
           sudo cat ~/.kube/config
           sudo microk8s.enable rbac dns
-          sudo sed -i 's/memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi/memory.available<50Mi,nodefs.available<250Mi,imagefs.available<250Mi/' /var/snap/microk8s/current/args/kubelet
+          sudo sed -i 's/memory.available<100Mi,nodefs.available<1Gi,imagefs.available<1Gi/memory.available<25Mi,nodefs.available<50Mi,imagefs.available<50Mi/' /var/snap/microk8s/current/args/kubelet
           sudo systemctl restart snap.microk8s.daemon-kubelet
           until sudo microk8s.status --wait-ready; do sleep 5s; echo "Try again"; done
           curl -L https://github.com/kubernetes-sigs/cri-tools/releases/download/${{ matrix.kube.crictl }}/crictl-${{ matrix.kube.crictl }}-linux-amd64.tar.gz --output crictl-${{ matrix.kube.crictl }}-linux-amd64.tar.gz

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -190,7 +190,9 @@ jobs:
         env:
           INSTALL_K3S_VERSION: ${{ matrix.kube.version }}
         run: |
-          sudo curl -sfL https://get.k3s.io | sh -
+          sudo curl -sfL https://get.k3s.io -o install.sh
+          sudo chmod +x install.sh
+          ./install.sh server --kubelet-arg=eviction-hard="imagefs.available<1%,nodefs.available<1%" --kubelet-arg=eviction-minimum-reclaim="imagefs.available=1%,nodefs.available=1%"
           sudo addgroup k3s-admin
           sudo adduser $USER k3s-admin
           sudo usermod -a -G k3s-admin $USER


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
E2e tests were failing due to the fact that GitHub runners have limited compute resources. 
A previous PR https://github.com/deislabs/akri/pull/301 reduced the failure occurrence for MicroK8s by reducing kubelet eviction limits. This one does the same for K3s, using the [recommendation from K3s FAQs](https://k3d.io/faq/faq/#pods-evicted-due-to-lack-of-disk-space).