### PR TITLE
Extend sleep in test case workflow to 45 minutes for component builds to complete [SAME VERSION]

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -288,8 +288,8 @@ jobs:
       # For push and release, we need to wait for the Helm chart and
       # associated containers to build.
       - if: github.event_name == 'push' || github.event_name == 'release'
-        name: Set sleep duration before running script to 1500
-        run: echo 1500 > /tmp/sleep_duration.txt
+        name: Set sleep duration before running script to 2700
+        run: echo 2700 > /tmp/sleep_duration.txt
 
       # For pull_request, use the locally built containers.
       - if: startsWith(github.event_name, 'pull_request')


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Upon merging, our Test K3s, Kubernetes, and MicroK8s workflow waits 25 minutes before starting, aiming to give the workflows that build our Rust code and component containers enough time to finish; however, the Rust build workflow takes around 40 minutes so the test workflow fails unless rerun once the containers are build. This extends the timeout 45 minutes.

**Special notes for your reviewer**:
To avoid an arbitrary sleep, a separate workflow should potentially be created for merges that waits for the building workflows to finish.
