### PR TITLE
Remove branch specification from dependent container build workflows [SAME VERSION]

### DIFF
--- a/.github/workflows/build-agent-container.yml
+++ b/.github/workflows/build-agent-container.yml
@@ -3,7 +3,6 @@ name: Build Agents
 on:
   workflow_run:
     workflows: ["Build Production Rust Code"]
-    branches: [main]
     types: 
       - completed
 

--- a/.github/workflows/build-controller-container.yml
+++ b/.github/workflows/build-controller-container.yml
@@ -3,7 +3,6 @@ name: Build Controller
 on:
   workflow_run:
     workflows: ["Build Production Rust Code"]
-    branches: [main]
     types: 
       - completed
 

--- a/.github/workflows/build-discovery-handlers.yml
+++ b/.github/workflows/build-discovery-handlers.yml
@@ -3,7 +3,6 @@ name: Build Discovery Handlers
 on:
   workflow_run:
     workflows: ["Build Production Rust Code"]
-    branches: [main]
     types: 
       - completed
 

--- a/.github/workflows/build-udev-video-broker-container.yml
+++ b/.github/workflows/build-udev-video-broker-container.yml
@@ -3,7 +3,6 @@ name: Build UDEV Broker
 on:
   workflow_run:
     workflows: ["Build Production Rust Code"]
-    branches: [main]
     types: 
       - completed
 

--- a/.github/workflows/build-webhook-configuration-container.yml
+++ b/.github/workflows/build-webhook-configuration-container.yml
@@ -3,7 +3,6 @@ name: Build Webhook Configuration
 on:
   workflow_run:
     workflows: ["Build Production Rust Code"]
-    branches: [main]
     types: 
       - completed
 


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Upon creating a release, our workflows that are dependent on the Build Production Rust Code workflow are not triggered due to the `main` branch specification.