### PR TITLE
Increase ONVIF Discovery Handler memory requests and limits [SAME VERSION]

### DIFF
--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -415,11 +415,11 @@ onvif:
       memoryRequest: 11Mi
       # cpuRequest defines the minimum amount of CPU that must be available to this Pod
       # for it to be scheduled by the Kubernetes Scheduler
-      cpuRequest: 10m
+      cpuRequest: 300m
       # memoryLimit defines the maximum amount of RAM this Pod can consume.
       memoryLimit: 24Mi
       # cpuLimit defines the maximum amount of CPU this Pod can consume.
-      cpuLimit: 24m
+      cpuLimit: 1300m
 
 opcua:
   configuration:


### PR DESCRIPTION
**What this PR does / why we need it**:
The ONVIF discovery handler seems to get stuck on a discovery thread, failing to timeout, unless enough CPU is allocated to the container. Further investigation should be done as to why the tokio runtime isn't enabling multiple tasks to run. It may just be that it takes a longer time for tasks to switch.

For now, increase the requests and limits. 