### PR TITLE
Fix Kubernetes installation in e2e tests

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -232,6 +232,10 @@ jobs:
         name: Install Kubernetes
         run: |
           sudo apt-get update -y
+          sudo apt-get install -y apt-transport-https ca-certificates curl
+          sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+          echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+          sudo apt-get update
           sudo apt-get install -o Dpkg::Options::="--force-overwrite" -y --allow-downgrades kubelet=${{ matrix.kube.version }} kubeadm=${{ matrix.kube.version }} kubectl=${{ matrix.kube.version }} 
           kubectl version && echo "kubectl return code: $?" || echo "kubectl return code: $?"
           kubeadm version && echo "kubeadm return code: $?" || echo "kubeadm return code: $?"


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
Our e2e tests are failing to install Vanilla Kubernetes since apt is not recognizing `kubelet`, `kubeadm` or `kubectl`. The Kubernetes apt repository must explicitly be added to the GitHub runners, as explained in [Kubernetes documentation](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl).
