### PR TITLE
docs: add info about openssl, pkg-config deps

### DIFF
--- a/docs/discovery-handler-development.md
+++ b/docs/discovery-handler-development.md
@@ -146,7 +146,24 @@ deleted Configuration.
 
 ## Creating a Discovery Handler in Rust using a template
 Rust Discovery Handler development can be kick-started using Akri's [Discovery Handler template](https://github.com/kate-goldenring/akri-discovery-handler-template) and
-[`cargo-generate`](https://github.com/cargo-generate/cargo-generate). Specify the name of your project.
+[`cargo-generate`](https://github.com/cargo-generate/cargo-generate).
+
+> NOTE: `cargo-generate` depends on `openssl-dev` and `pkg-config` and need to be installed beforehand
+
+__GNU/Linux__:
+
+```sh
+apt install -y openssl-dev pkg-config
+```
+
+__macOS__:
+
+```sh
+brew install openssl@1.1 pkg-config
+```
+
+Proceed to install `cargo-generate` and specify the name of the project with the `--name` parameter.
+
 ```sh 
 cargo install cargo-generate
 cargo generate --git https://github.com/kate-goldenring/akri-discovery-handler-template.git --name akri-discovery-handler

--- a/docs/discovery-handler-development.md
+++ b/docs/discovery-handler-development.md
@@ -148,24 +148,10 @@ deleted Configuration.
 Rust Discovery Handler development can be kick-started using Akri's [Discovery Handler template](https://github.com/kate-goldenring/akri-discovery-handler-template) and
 [`cargo-generate`](https://github.com/cargo-generate/cargo-generate).
 
-> NOTE: `cargo-generate` depends on `openssl-dev` and `pkg-config` and need to be installed beforehand
-
-__GNU/Linux__:
-
-```sh
-apt install -y openssl-dev pkg-config
-```
-
-__macOS__:
+Install by following the [`cargo-generate` instruction](https://github.com/cargo-generate/cargo-generate#installation) and 
+specify the name of the project with the `--name` parameter.
 
 ```sh
-brew install openssl@1.1 pkg-config
-```
-
-Proceed to install `cargo-generate` and specify the name of the project with the `--name` parameter.
-
-```sh 
-cargo install cargo-generate
 cargo generate --git https://github.com/kate-goldenring/akri-discovery-handler-template.git --name akri-discovery-handler
 ```
 This template abstracts away the work of registering with the Agent and creating the Discovery Handler service. All you

--- a/docs/discovery-handler-development.md
+++ b/docs/discovery-handler-development.md
@@ -148,8 +148,8 @@ deleted Configuration.
 Rust Discovery Handler development can be kick-started using Akri's [Discovery Handler template](https://github.com/kate-goldenring/akri-discovery-handler-template) and
 [`cargo-generate`](https://github.com/cargo-generate/cargo-generate).
 
-Install by following the [`cargo-generate` instruction](https://github.com/cargo-generate/cargo-generate#installation) and 
-specify the name of the project with the `--name` parameter.
+Install [`cargo-generate`](https://github.com/cargo-generate/cargo-generate#installation) and 
+use the tool to pull down Akri's template, specifying the name of the project with the `--name` parameter.
 
 ```sh
 cargo generate --git https://github.com/kate-goldenring/akri-discovery-handler-template.git --name akri-discovery-handler

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -29,8 +29,6 @@ the Agent, which hosts the `Registration` service defined in the gRPC interface.
 
 ## New DiscoveryHandler implementation
 ### Use `cargo generate` to clone the Discovery Handler template
-Pull down the [Discovery Handler template](https://github.com/kate-goldenring/akri-discovery-handler-template) using
-[`cargo-generate`](https://github.com/cargo-generate/cargo-generate). 
 
 Install [`cargo-generate`](https://github.com/cargo-generate/cargo-generate#installation) and 
 use the tool to pull down Akri's template, specifying the name of the project with the `--name` parameter.

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -31,6 +31,23 @@ the Agent, which hosts the `Registration` service defined in the gRPC interface.
 ### Use `cargo generate` to clone the Discovery Handler template
 Pull down the [Discovery Handler template](https://github.com/kate-goldenring/akri-discovery-handler-template) using
 [`cargo-generate`](https://github.com/cargo-generate/cargo-generate). 
+
+> NOTE: `cargo-generate` depends on `openssl-dev` and `pkg-config` and need to be installed beforehand
+
+__GNU/Linux__:
+
+```sh
+apt install -y openssl-dev pkg-config
+```
+
+__macOS__:
+
+```sh
+brew install openssl@1.1 pkg-config
+```
+
+Proceed to install `cargo-generate` and specify the name of the project with the `--name` parameter.
+
 ```sh 
 cargo install cargo-generate
 cargo generate --git https://github.com/kate-goldenring/akri-discovery-handler-template.git --name akri-http-discovery-handler

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -32,8 +32,8 @@ the Agent, which hosts the `Registration` service defined in the gRPC interface.
 Pull down the [Discovery Handler template](https://github.com/kate-goldenring/akri-discovery-handler-template) using
 [`cargo-generate`](https://github.com/cargo-generate/cargo-generate). 
 
-Install by following the [`cargo-generate` instruction](https://github.com/cargo-generate/cargo-generate#installation) and 
-specify the name of the project with the `--name` parameter.
+Install [`cargo-generate`](https://github.com/cargo-generate/cargo-generate#installation) and 
+use the tool to pull down Akri's template, specifying the name of the project with the `--name` parameter.
 
 ```sh
 cargo generate --git https://github.com/kate-goldenring/akri-discovery-handler-template.git --name akri-http-discovery-handler

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -32,24 +32,10 @@ the Agent, which hosts the `Registration` service defined in the gRPC interface.
 Pull down the [Discovery Handler template](https://github.com/kate-goldenring/akri-discovery-handler-template) using
 [`cargo-generate`](https://github.com/cargo-generate/cargo-generate). 
 
-> NOTE: `cargo-generate` depends on `openssl-dev` and `pkg-config` and need to be installed beforehand
-
-__GNU/Linux__:
-
-```sh
-apt install -y openssl-dev pkg-config
-```
-
-__macOS__:
+Install by following the [`cargo-generate` instruction](https://github.com/cargo-generate/cargo-generate#installation) and 
+specify the name of the project with the `--name` parameter.
 
 ```sh
-brew install openssl@1.1 pkg-config
-```
-
-Proceed to install `cargo-generate` and specify the name of the project with the `--name` parameter.
-
-```sh 
-cargo install cargo-generate
 cargo generate --git https://github.com/kate-goldenring/akri-discovery-handler-template.git --name akri-http-discovery-handler
 ```
 ### Specify the DiscoveryHandler name and whether discovered devices are sharable


### PR DESCRIPTION
- Without previous installation of `openssl-dev`, `pkg-config`,
  `cargo install cargo-generate` will fail.
- Potential solution is to install the respective dependencies beforehand

Tested On: Windows10 Pro + WSL2 (Ubuntu-20.04 LTS) + rustc > v1.51
Possible Solution found on: https://github.com/sfackler/rust-openssl/issues/951

Signed-off-by: Shan Desai <shantanoo.desai@gmail.com>

<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:

Additional Information in Documentation for creating a custom discovery handler.

**Special notes for your reviewer**:

**If applicable**:
- [x] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)