### PR TITLE
Create akri as the default namespace

### DIFF
--- a/deployment/helm/templates/agent.yaml
+++ b/deployment/helm/templates/agent.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: akri-agent-daemonset
+  namespace: {{ .Values.namespace.name }}
 spec:
   selector:
     matchLabels:

--- a/deployment/helm/templates/controller.yaml
+++ b/deployment/helm/templates/controller.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: akri-controller-deployment
+  namespace: {{ .Values.namespace.name }}
 spec:
   replicas: 1
   selector:

--- a/deployment/helm/templates/custom-configuration.yaml
+++ b/deployment/helm/templates/custom-configuration.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/%s" .Values.crds.group .Values.crds.version }}
 kind: Configuration
 metadata:
   name: {{ .Values.custom.configuration.name }}
+  namespace: {{ .Values.namespace.name }}
 spec:
   discoveryHandler: 
     name: {{ required "A custom.configuration.discoveryHandlerName is required." .Values.custom.configuration.discoveryHandlerName }}

--- a/deployment/helm/templates/custom-discovery-handler.yaml
+++ b/deployment/helm/templates/custom-discovery-handler.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ printf "%s-daemonset" .Values.custom.discovery.name }}
+  namespace: {{ .Values.namespace.name }}
 spec:
   selector:
     matchLabels:

--- a/deployment/helm/templates/debug-echo-configuration.yaml
+++ b/deployment/helm/templates/debug-echo-configuration.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/%s" .Values.crds.group .Values.crds.version }}
 kind: Configuration
 metadata:
   name: {{ .Values.debugEcho.configuration.name }}
+  namespace: {{ .Values.namespace.name }}
 spec:
   discoveryHandler: 
     name: debugEcho

--- a/deployment/helm/templates/debug-echo-discovery-handler.yaml
+++ b/deployment/helm/templates/debug-echo-discovery-handler.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: akri-debug-echo-discovery-daemonset
+  namespace: {{ .Values.namespace.name }}
 spec:
   selector:
     matchLabels:

--- a/deployment/helm/templates/namespace.yaml
+++ b/deployment/helm/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name }}

--- a/deployment/helm/templates/onvif-configuration.yaml
+++ b/deployment/helm/templates/onvif-configuration.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/%s" .Values.crds.group .Values.crds.version }}
 kind: Configuration
 metadata:
   name: {{ .Values.onvif.configuration.name }}
+  namespace: {{ .Values.namespace.name }}
 spec:
   discoveryHandler:
     name: onvif

--- a/deployment/helm/templates/onvif-discovery-handler.yaml
+++ b/deployment/helm/templates/onvif-discovery-handler.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: akri-onvif-discovery-daemonset
+  namespace: {{ .Values.namespace.name }}
 spec:
   selector:
     matchLabels:

--- a/deployment/helm/templates/opcua-configuration.yaml
+++ b/deployment/helm/templates/opcua-configuration.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/%s" .Values.crds.group .Values.crds.version }}
 kind: Configuration
 metadata:
   name: {{ .Values.opcua.configuration.name }}
+  namespace: {{ .Values.namespace.name }}
 spec:
   discoveryHandler:
     name: opcua

--- a/deployment/helm/templates/opcua-discovery-handler.yaml
+++ b/deployment/helm/templates/opcua-discovery-handler.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: akri-opcua-discovery-daemonset
+  namespace: {{ .Values.namespace.name }}
 spec:
   selector:
     matchLabels:

--- a/deployment/helm/templates/prometheus.yaml
+++ b/deployment/helm/templates/prometheus.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: akri-agent-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
   labels:
     release: prometheus
 spec:
@@ -18,7 +18,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: akri-controller-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
   labels:
     release: prometheus
 spec:

--- a/deployment/helm/templates/rbac.yaml
+++ b/deployment/helm/templates/rbac.yaml
@@ -15,7 +15,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "akri-controller-role"
-  namespace: {{ .Values.namespace.name }}
 rules:
 - apiGroups: [""]
   resources: ["pods", "services"]
@@ -34,7 +33,6 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "akri-agent-role"
-  namespace: {{ .Values.namespace.name }}
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -50,7 +48,6 @@ apiVersion: 'rbac.authorization.k8s.io/v1'
 kind: 'ClusterRoleBinding'
 metadata:
   name: 'akri-controller-binding'
-  namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
 roleRef:
   apiGroup: ''
   kind: 'ClusterRole'
@@ -64,7 +61,6 @@ apiVersion: 'rbac.authorization.k8s.io/v1'
 kind: 'ClusterRoleBinding'
 metadata:
   name: 'akri-agent-binding'
-  namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
 roleRef:
   apiGroup: ''
   kind: 'ClusterRole'

--- a/deployment/helm/templates/rbac.yaml
+++ b/deployment/helm/templates/rbac.yaml
@@ -3,16 +3,19 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: akri-controller-sa
+  namespace: {{ .Values.namespace.name }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: akri-agent-sa
+  namespace: {{ .Values.namespace.name }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "akri-controller-role"
+  namespace: {{ .Values.namespace.name }}
 rules:
 - apiGroups: [""]
   resources: ["pods", "services"]
@@ -31,6 +34,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: "akri-agent-role"
+  namespace: {{ .Values.namespace.name }}
 rules:
 - apiGroups: [""]
   resources: ["pods"]
@@ -46,7 +50,7 @@ apiVersion: 'rbac.authorization.k8s.io/v1'
 kind: 'ClusterRoleBinding'
 metadata:
   name: 'akri-controller-binding'
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
 roleRef:
   apiGroup: ''
   kind: 'ClusterRole'
@@ -54,13 +58,13 @@ roleRef:
 subjects:
   - kind: 'ServiceAccount'
     name: 'akri-controller-sa'
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
 ---
 apiVersion: 'rbac.authorization.k8s.io/v1'
 kind: 'ClusterRoleBinding'
 metadata:
   name: 'akri-agent-binding'
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
 roleRef:
   apiGroup: ''
   kind: 'ClusterRole'
@@ -68,5 +72,5 @@ roleRef:
 subjects:
   - kind: 'ServiceAccount'
     name: 'akri-agent-sa'
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
 {{- end }}

--- a/deployment/helm/templates/udev-configuration.yaml
+++ b/deployment/helm/templates/udev-configuration.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ printf "%s/%s" .Values.crds.group .Values.crds.version }}
 kind: Configuration
 metadata:
   name: {{ .Values.udev.configuration.name }}
+  namespace: {{ .Values.namespace.name }}
 spec:
   discoveryHandler:
     name: udev

--- a/deployment/helm/templates/udev-discovery-handler.yaml
+++ b/deployment/helm/templates/udev-discovery-handler.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: akri-udev-discovery-daemonset
+  namespace: {{ .Values.namespace.name }}
 spec:
   selector:
     matchLabels:

--- a/deployment/helm/templates/webhook-configuration.yaml
+++ b/deployment/helm/templates/webhook-configuration.yaml
@@ -9,12 +9,12 @@ items:
     kind: ServiceAccount
     metadata:
       name: {{ .Values.webhookConfiguration.name }}
-      namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
+      namespace: {{ .Values.namespace.name }}
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
       name: {{ .Values.webhookConfiguration.name }}
-      namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
+      namespace: {{ .Values.namespace.name }}
     rules:
     - apiGroups: [""]
       resources: ["pods"]
@@ -23,7 +23,7 @@ items:
     kind: RoleBinding
     metadata:
       name: {{ .Values.webhookConfiguration.name }}
-      namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
+      namespace: {{ .Values.namespace.name }}
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
@@ -31,7 +31,7 @@ items:
     subjects:
     - kind: ServiceAccount
       name: {{ .Values.webhookConfiguration.name }}
-      namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
+      namespace: {{ .Values.namespace.name }}
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -131,7 +131,7 @@ items:
         clientConfig:
           service:
             name: {{ .Values.webhookConfiguration.name }}
-            namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
+            namespace: {{ .Values.namespace.name }}
             port: 443
             path: "/validate"
           caBundle: {{ required "please rerun helm install" .Values.webhookConfiguration.caBundle }}

--- a/deployment/helm/templates/webhook-configuration.yaml
+++ b/deployment/helm/templates/webhook-configuration.yaml
@@ -3,17 +3,18 @@ apiVersion: v1
 kind: List
 metadata:
   name: {{ .Values.webhookConfiguration.name }}
+  namespace: {{ .Values.namespace.name }}
 items:
   - apiVersion: v1
     kind: ServiceAccount
     metadata:
       name: {{ .Values.webhookConfiguration.name }}
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
       name: {{ .Values.webhookConfiguration.name }}
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
     rules:
     - apiGroups: [""]
       resources: ["pods"]
@@ -22,7 +23,7 @@ items:
     kind: RoleBinding
     metadata:
       name: {{ .Values.webhookConfiguration.name }}
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
@@ -30,11 +31,12 @@ items:
     subjects:
     - kind: ServiceAccount
       name: {{ .Values.webhookConfiguration.name }}
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: {{ .Values.webhookConfiguration.name }}
+      namespace: {{ .Values.namespace.name }}
     spec:
       replicas: 1
       selector:
@@ -111,6 +113,7 @@ items:
     kind: Service
     metadata:
       name: {{ .Values.webhookConfiguration.name }}
+      namespace: {{ .Values.namespace.name }}
     spec:
       selector:
         app: {{ .Values.webhookConfiguration.name }}
@@ -122,12 +125,13 @@ items:
     kind: ValidatingWebhookConfiguration
     metadata:
       name: {{ .Values.webhookConfiguration.name }}
+      namespace: {{ .Values.namespace.name }}
     webhooks:
       - name: {{ .Values.webhookConfiguration.name }}.{{ .Release.Namespace }}.svc
         clientConfig:
           service:
             name: {{ .Values.webhookConfiguration.name }}
-            namespace: {{ .Release.Namespace }}
+            namespace: {{ .Values.namespace.name }} # Previous .Release.Namespace
             port: 443
             path: "/validate"
           caBundle: {{ required "please rerun helm install" .Values.webhookConfiguration.caBundle }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -25,6 +25,11 @@ rbac:
   # enabled defines whether to apply rbac to Akri
   enabled: true
 
+# namespace is the Kubernetes namespace that will be created for storing
+# Akri related deployments
+namespace:
+  name: akri
+
 prometheus:
   # enabled defines whether metrics ports are exposed on
   # the Controller and Agent


### PR DESCRIPTION
**What this PR does / why we need it**:

Solves #294 

 This creates a new default namespace (named "akri") for akri components and would be used if the user does not specify a particular namespace. 

 This particular implementation comes with pros and cons when dealing with helm templates, here is a summary.

**Pros**:

 If a user doesn't specify a namespace it makes sense for it to be arranged in an organized namespace and creates a good standard for Akri usage.

 By default Akri won't pollute the cluster's default namespace.

**Cons**:

 Helm doesn't support creating new default namespace other than "default", so this particular implementation creates it via template.

 What that means is that if the user specify the namespace during Akri's helm installation (for example "-n iot") it would still be deployed to the "akri" namespace. It is still possible to change it, but it is required to override the `.Values.namespace.name` variable to set a custom namespace, contradicting the helm already established conventions.

 Since now a namespace creation is part of the template it could result in some problems, for example if the user uninstall Akri the namespace it was present would also be deleted, even if some non-akri related components were deployed there.

**Conclusion**:

 My conclusion is that we should stick with Helms patterns and good practice conventions and not set a namespace via templates for now, leaving it to the user decide where to deploy Akri. It is still a good feature to keep in mind and this Issue could definitely be reviewed if we see any updates to this aspect of Helm. 

 We should still update our documentation in order to incentivize the creation of an Akri namespace during installation, so we could still hit our goal to cut the number of components on the default namespace. 
