### PR TITLE
Reduce Size of OpenCV Intermediate Container [SAME VERSION] [ALLOW INTERMEDIATE BUILDS]

### DIFF
--- a/build/containers/intermediate/Dockerfile.opencvsharp-build
+++ b/build/containers/intermediate/Dockerfile.opencvsharp-build
@@ -139,17 +139,14 @@ RUN git clone https://github.com/shimat/opencvsharp.git && \
 	git fetch --all --tags --prune && git checkout ${OPENCV_SHARP_VERSION}
 
 # Install Build the C# part of OpenCvSharp
-# WORKDIR /opencvsharp/src/OpenCvSharp
 RUN cd /opencvsharp/src/OpenCvSharp && \
     dotnet build -c Release -f netstandard2.0 
 
-# WORKDIR /opencvsharp/src/OpenCvSharp.Extensions
 RUN cd /opencvsharp/src/OpenCvSharp.Extensions && \
     dotnet build -c Release -f netstandard2.0 
 
 RUN mkdir /opencvsharp/build && \
     cd /opencvsharp/build && \
-    # cp /libOpenCvSharpExtern.so . && \
     cp /opencvsharp/src/OpenCvSharp/bin/Release/netstandard2.0/* . && \
     cp /opencvsharp/src/OpenCvSharp.Extensions/bin/Release/netstandard2.0/* .
 

--- a/build/containers/intermediate/Dockerfile.opencvsharp-build
+++ b/build/containers/intermediate/Dockerfile.opencvsharp-build
@@ -27,17 +27,36 @@ ENV OPENCV_SHARP_VERSION="4.1.0.20190417"
 RUN whoami
 RUN pwd
 
-RUN apt update && \
-	apt -y install build-essential cmake pkg-config yasm git gfortran \
-	libjpeg-dev libpng-dev libtiff-dev libavcodec-dev \ 
-	libavformat-dev libswscale-dev libdc1394-22-dev libxine2-dev libv4l-dev \
-	libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgtk2.0-dev libtbb-dev \
-	qt5-default libatlas-base-dev libmp3lame-dev libtheora-dev \
-	libvorbis-dev libxvidcore-dev libopencore-amrnb-dev libopencore-amrwb-dev \
-	libavresample-dev x264 v4l-utils libprotobuf-dev protobuf-compiler \
-	libgoogle-glog-dev libgflags-dev libgphoto2-dev libeigen3-dev libhdf5-dev doxygen \
-	libtbb2 libdc1394-22-dev unzip wget && \
-	apt clean
+# Install opencv dependencies
+RUN apt-get update && apt-get -y install --no-install-recommends \
+    apt-transport-https \
+    software-properties-common \
+    wget \
+    unzip \
+    ca-certificates \
+    build-essential \
+    cmake \
+    git \
+    libtbb-dev \
+    libatlas-base-dev \
+    libgtk2.0-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libdc1394-22-dev \
+    libxine2-dev \
+    libv4l-dev \
+    libtheora-dev \
+    libvorbis-dev \
+    libxvidcore-dev \
+    libopencore-amrnb-dev \
+    libopencore-amrwb-dev \
+    libavresample-dev \
+    x264 \
+    libtesseract-dev \
+    libgdiplus \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir ${OPENCV_INSTALLATION_DIR} && \
 	cd ${OPENCV_INSTALLATION_DIR} && \
@@ -46,19 +65,55 @@ RUN mkdir ${OPENCV_INSTALLATION_DIR} && \
 	wget https://github.com/opencv/opencv_contrib/archive/${OPENCV_VERSION}.zip -Oopencv_contrib-${OPENCV_VERSION}.zip && \
 	unzip opencv_contrib-${OPENCV_VERSION}.zip && \
 	rm ${OPENCV_INSTALLATION_DIR}/*.zip && \
-	cd ${OPENCV_INSTALLATION_DIR}/opencv-${OPENCV_VERSION} && \
-	ln -s /usr/include/eigen3/Eigen /usr/include/Eigen
+	cd ${OPENCV_INSTALLATION_DIR}/opencv-${OPENCV_VERSION} 
+	
 	
 RUN cd ${OPENCV_INSTALLATION_DIR}/opencv-${OPENCV_VERSION} && \
     mkdir build && cd build && \
-	cmake .. -DCMAKE_BUILD_TYPE=Release -DOPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${OPENCV_VERSION}/modules && \
-	make -j$(grep -c ^processor /proc/cpuinfo) && \
+	cmake \
+    -D CMAKE_BUILD_TYPE=RELEASE \
+    -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${OPENCV_VERSION}/modules \
+    -D BUILD_SHARED_LIBS=OFF \
+    -D ENABLE_CXX11=ON \
+    -D BUILD_EXAMPLES=OFF \
+    -D BUILD_DOCS=OFF \
+    -D BUILD_PERF_TESTS=OFF \
+    -D BUILD_TESTS=OFF \
+    -D BUILD_JAVA=OFF \
+    -D BUILD_opencv_app=OFF \
+    -D BUILD_opencv_barcode=OFF \
+    -D BUILD_opencv_java_bindings_generator=OFF \
+    -D BUILD_opencv_js_bindings_generator=OFF \
+    -D BUILD_opencv_python_bindings_generator=OFF \
+    -D BUILD_opencv_python_tests=OFF \
+    -D BUILD_opencv_ts=OFF \
+    -D BUILD_opencv_js=OFF \
+    -D BUILD_opencv_bioinspired=OFF \
+    -D BUILD_opencv_ccalib=OFF \
+    -D BUILD_opencv_datasets=OFF \
+    -D BUILD_opencv_dnn_objdetect=OFF \
+    -D BUILD_opencv_dpm=OFF \
+    -D BUILD_opencv_fuzzy=OFF \
+    -D BUILD_opencv_gapi=OFF \
+    -D BUILD_opencv_intensity_transform=OFF \
+    -D BUILD_opencv_mcc=OFF \
+    -D BUILD_opencv_objc_bindings_generator=OFF \
+    -D BUILD_opencv_rapid=OFF \
+    -D BUILD_opencv_reg=OFF \
+    -D BUILD_opencv_stereo=OFF \
+    -D BUILD_opencv_structured_light=OFF \
+    -D BUILD_opencv_surface_matching=OFF \
+    -D BUILD_opencv_videostab=OFF \
+    -D BUILD_opencv_wechat_qrcode=OFF \
+    -D WITH_GSTREAMER=OFF \
+    -D OPENCV_ENABLE_NONFREE=ON \
+    .. && make -j$(grep -c ^processor /proc/cpuinfo) && \
 	make install -j8 && \
 	ldconfig && \
 	cd && \
 	rm -r ${OPENCV_INSTALLATION_DIR}/opencv-${OPENCV_VERSION} && \
 	rm -r ${OPENCV_INSTALLATION_DIR}/opencv_contrib-${OPENCV_VERSION}
-	
+
 RUN cd ${OPENCV_INSTALLATION_DIR} && \
 	git clone https://github.com/shimat/opencvsharp.git opencvsharp && \
 	cd opencvsharp && \
@@ -75,3 +130,31 @@ RUN cd ${OPENCV_INSTALLATION_DIR} && \
 	rm -r ${OPENCV_INSTALLATION_DIR}/opencvsharp && \
 	apt remove -y git unzip wget build-essential cmake && \
 	apt autoremove -y
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-dotnet-env
+WORKDIR /
+COPY --from=base /usr/lib/libOpenCvSharpExtern.so ./
+RUN git clone https://github.com/shimat/opencvsharp.git && \
+	cd opencvsharp && \
+	git fetch --all --tags --prune && git checkout ${OPENCV_SHARP_VERSION}
+
+# Install Build the C# part of OpenCvSharp
+# WORKDIR /opencvsharp/src/OpenCvSharp
+RUN cd /opencvsharp/src/OpenCvSharp && \
+    dotnet build -c Release -f netstandard2.0 
+
+# WORKDIR /opencvsharp/src/OpenCvSharp.Extensions
+RUN cd /opencvsharp/src/OpenCvSharp.Extensions && \
+    dotnet build -c Release -f netstandard2.0 
+
+RUN mkdir /opencvsharp/build && \
+    cd /opencvsharp/build && \
+    # cp /libOpenCvSharpExtern.so . && \
+    cp /opencvsharp/src/OpenCvSharp/bin/Release/netstandard2.0/* . && \
+    cp /opencvsharp/src/OpenCvSharp.Extensions/bin/Release/netstandard2.0/* .
+
+# Copy over OpenCvSharp binaries and OpenCvSharpExtern shared library
+FROM mcr.microsoft.com/dotnet/core/aspnet:${PLATFORM_TAG}
+WORKDIR /app
+COPY --from=build-dotnet-env /opencvsharp/build ./
+COPY --from=build-dotnet-env /libOpenCvSharpExtern.so /usr/lib

--- a/build/containers/intermediate/Dockerfile.opencvsharp-build
+++ b/build/containers/intermediate/Dockerfile.opencvsharp-build
@@ -109,10 +109,7 @@ RUN cd ${OPENCV_INSTALLATION_DIR}/opencv-${OPENCV_VERSION} && \
     -D OPENCV_ENABLE_NONFREE=ON \
     .. && make -j$(grep -c ^processor /proc/cpuinfo) && \
 	make install -j8 && \
-	ldconfig && \
-	cd && \
-	rm -r ${OPENCV_INSTALLATION_DIR}/opencv-${OPENCV_VERSION} && \
-	rm -r ${OPENCV_INSTALLATION_DIR}/opencv_contrib-${OPENCV_VERSION}
+	ldconfig
 
 RUN cd ${OPENCV_INSTALLATION_DIR} && \
 	git clone https://github.com/shimat/opencvsharp.git opencvsharp && \
@@ -125,11 +122,7 @@ RUN cd ${OPENCV_INSTALLATION_DIR} && \
 	make -j$(grep -c ^processor /proc/cpuinfo) && \
 	make install && \
 	ldconfig && \
-	cp OpenCvSharpExtern/libOpenCvSharpExtern.so /usr/lib && \
-	cd && \
-	rm -r ${OPENCV_INSTALLATION_DIR}/opencvsharp && \
-	apt remove -y git unzip wget build-essential cmake && \
-	apt autoremove -y
+	cp OpenCvSharpExtern/libOpenCvSharpExtern.so /usr/lib
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build-dotnet-env
 WORKDIR /

--- a/build/containers/intermediate/Dockerfile.opencvsharp-build
+++ b/build/containers/intermediate/Dockerfile.opencvsharp-build
@@ -148,3 +148,14 @@ FROM mcr.microsoft.com/dotnet/core/aspnet:${PLATFORM_TAG}
 WORKDIR /app
 COPY --from=build-dotnet-env /opencvsharp/build ./
 COPY --from=build-dotnet-env /libOpenCvSharpExtern.so /usr/lib
+# Install OpenCVSharpEntern dependencies
+RUN apt-get update && apt-get -y install --no-install-recommends \
+    libgtk2.0-dev \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libdc1394-22-dev \
+    libavresample-dev \
+    libtesseract-dev \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/build/intermediate-containers.mk
+++ b/build/intermediate-containers.mk
@@ -1,7 +1,7 @@
 
 BUILD_RUST_CROSSBUILD_VERSION = 0.0.7
 
-BUILD_OPENCV_BASE_VERSION = 0.0.7
+BUILD_OPENCV_BASE_VERSION = 0.0.8
 
 CROSS_VERSION = 0.1.16
 
@@ -10,7 +10,7 @@ CROSS_VERSION = 0.1.16
 # OPENCV: make and push the open cv intermediate images:
 #
 #    To make all platforms: `make opencv-base`
-#    To make specific platforms: `BUILD_AMD64=1 BUILD_ARM32=0 BUILD_ARM64=1 make opencv`
+#    To make specific platforms: `BUILD_AMD64=1 BUILD_ARM32=0 BUILD_ARM64=1 make opencv-base`
 #
 #
 .PHONY: opencv-base


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://github.com/deislabs/akri/blob/main/docs/contributing.md
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
This PR reduces the size of the intermediate container for our ONVIF video broker from 1.82 GB -> ~296 MB~ 665MB
A second PR will modify the onvif-video-broker container to leverage this smaller intermediate container
 
**Special notes for your reviewer**:
Reduction comes from copying over only the OpenCV Entern statically-linked shared library and OpenCV C# binaries