### PR TITLE
[SAME VERSION] Workflow to mark inactive issues/PRs as stale and eventually close them

### DIFF
--- a/.github/workflows/stale-tasks.yml
+++ b/.github/workflows/stale-tasks.yml
@@ -1,4 +1,4 @@
-# This is a workflow that runs periodically to mark issues/prs with no recent activity as stale, it also closes/removes-label based on following activity
+# This is a workflow that runs periodically to mark issues/prs with no recent activity as stale, it also closes/removes label based on following activity
 
 name: Mark and close stale issues/PRs
 on:

--- a/.github/workflows/stale-tasks.yml
+++ b/.github/workflows/stale-tasks.yml
@@ -1,6 +1,6 @@
 # This is a workflow that runs periodically to mark issues/prs with no recent activity as stale, it also closes/removes-label based on following activity
 
-name: Close stale issues
+name: Mark and close stale issues/PRs
 on:
   schedule:
   - cron: '0 0 * * *' # runs daily at 12:00 am UTC
@@ -19,7 +19,6 @@ jobs:
           stale-issue-message: > 
             Issue has been automatically marked as stale because it has been open for 45 days with no activity. Issue will be closed if no further activity occurs.
             Thank you for your contributions.
-          close-issue-message: 'This issue was closed because it has been stalled with no activity.'
           stale-pr-message: > 
             PR has been automatically marked as stale because it has been open for 45 days with no activity. PR will be closed if no further activity occurs.
             Thank you for your contributions.

--- a/.github/workflows/stale-tasks.yml
+++ b/.github/workflows/stale-tasks.yml
@@ -1,0 +1,21 @@
+# This is a workflow that runs periodically to mark issues with no recent activity as stale, it also closes/removes-label based on following activities
+
+name: Close stale issues
+on:
+  schedule:
+  - cron: '0 0 * * *' # runs daily at 12:00 am UTC
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-label: stale
+          days-before-stale: 30
+          days-before-close: 5
+          remove-issue-stale-when-updated: true
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          days-before-pr-close: -1  # do not close PRs
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale-tasks.yml
+++ b/.github/workflows/stale-tasks.yml
@@ -1,4 +1,4 @@
-# This is a workflow that runs periodically to mark issues with no recent activity as stale, it also closes/removes-label based on following activities
+# This is a workflow that runs periodically to mark issues/prs with no recent activity as stale, it also closes/removes-label based on following activity
 
 name: Close stale issues
 on:
@@ -12,10 +12,16 @@ jobs:
       - uses: actions/stale@v4
         with:
           stale-issue-label: stale
-          days-before-stale: 30
-          days-before-close: 5
-          remove-issue-stale-when-updated: true
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
-          days-before-pr-close: -1  # do not close PRs
+          stale-pr-label: stale
+          days-before-stale: 45
+          days-before-close: 45
+          remove-stale-when-updated: true
+          stale-issue-message: > 
+            Issue has been automatically marked as stale because it has been open for 45 days with no activity. Issue will be closed if no further activity occurs.
+            Thank you for your contributions.
+          close-issue-message: 'This issue was closed because it has been stalled with no activity.'
+          stale-pr-message: > 
+            PR has been automatically marked as stale because it has been open for 45 days with no activity. PR will be closed if no further activity occurs.
+            Thank you for your contributions.
+          exempt-issue-labels: keep-alive
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Help keeping akri repo current by marking issues and PRs with no recent activity as stale and eventually closing them.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/deislabs/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)