### PR TITLE
[SAME VERSION] Enable stale action

### DIFF
--- a/.github/workflows/stale-tasks.yml
+++ b/.github/workflows/stale-tasks.yml
@@ -21,5 +21,4 @@ jobs:
           stale-pr-message: > 
             PR has been automatically marked as stale due to inactivity for 45 days. Update the PR to remove label, otherwise it will be automatically closed."
           exempt-issue-labels: keep-alive
-          token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enables stale action checked-in #363 & also fixes a typo in token param.

**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/deislabs/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)