### PR TITLE
Add K3s version 1.21.5 to test cases matrix [SAME VERSION]

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -136,6 +136,9 @@ jobs:
           - runtime: K3s-1.20
             version: v1.20.6+k3s1
             crictl: v1.17.0
+          - runtime: K3s-1.21
+            version: v1.21.5+k3s1
+            crictl: v1.17.0
           - runtime: Kubernetes-1.16
             version: 1.16.15-00
             crictl: UNUSED


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
In our test cases, we are testing MicroK8s and Kubernetes `v1.21` but only up to `v1.20` of K3s. This fixes that.