### PR TITLE
Add latest K8s version 1.22 to e2e tests [SAME VERSION]

### DIFF
--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -103,57 +103,66 @@ jobs:
       fail-fast: false
       matrix:
         kube:
-          - runtime: MicroK8s-1.16
-            version: 1.16/stable
-            crictl: v1.16.0
-          - runtime: MicroK8s-1.17
-            version: 1.17/stable
-            crictl: v1.16.0
-          - runtime: MicroK8s-1.18
-            version: 1.18/stable
+          - runtime: MicroK8s-latest
+            version: latest
             crictl: v1.17.0
-          - runtime: MicroK8s-1.19
-            version: 1.19/stable
+          - runtime: K3s-latest
+            version: latest
             crictl: v1.17.0
-          - runtime: MicroK8s-1.20
-            version: 1.20/stable
-            crictl: v1.17.0
-          - runtime: MicroK8s-1.21
-            version: 1.21/stable
-            crictl: v1.17.0
-          - runtime: K3s-1.16
-            version: v1.16.14+k3s1
-            crictl: v1.16.0
-          - runtime: K3s-1.17
-            version: v1.17.17+k3s1
-            crictl: v1.16.0
-          - runtime: K3s-1.18
-            version: v1.18.9+k3s1
-            crictl: v1.17.0
-          - runtime: K3s-1.19
-            version: v1.19.10+k3s1
-            crictl: v1.17.0
-          - runtime: K3s-1.20
-            version: v1.20.6+k3s1
-            crictl: v1.17.0
-          - runtime: Kubernetes-1.16
-            version: 1.16.15-00
+          - runtime: Kubernetes-latest
+            version: latest
             crictl: UNUSED
-          - runtime: Kubernetes-1.17
-            version: 1.17.14-00
-            crictl: UNUSED
-          - runtime: Kubernetes-1.18
-            version: 1.18.12-00
-            crictl: UNUSED
-          - runtime: Kubernetes-1.19
-            version: 1.19.4-00
-            crictl: UNUSED
-          - runtime: Kubernetes-1.20
-            version: 1.20.1-00
-            crictl: UNUSED
-          - runtime: Kubernetes-1.21
-            version: 1.21.0-00
-            crictl: UNUSED
+          # - runtime: MicroK8s-1.16
+          #   version: 1.16/stable
+          #   crictl: v1.16.0
+          # - runtime: MicroK8s-1.17
+          #   version: 1.17/stable
+          #   crictl: v1.16.0
+          # - runtime: MicroK8s-1.18
+          #   version: 1.18/stable
+          #   crictl: v1.17.0
+          # - runtime: MicroK8s-1.19
+          #   version: 1.19/stable
+          #   crictl: v1.17.0
+          # - runtime: MicroK8s-1.20
+          #   version: 1.20/stable
+          #   crictl: v1.17.0
+          # - runtime: MicroK8s-1.21
+          #   version: 1.21/stable
+          #   crictl: v1.17.0
+          # - runtime: K3s-1.16
+          #   version: v1.16.14+k3s1
+          #   crictl: v1.16.0
+          # - runtime: K3s-1.17
+          #   version: v1.17.17+k3s1
+          #   crictl: v1.16.0
+          # - runtime: K3s-1.18
+          #   version: v1.18.9+k3s1
+          #   crictl: v1.17.0
+          # - runtime: K3s-1.19
+          #   version: v1.19.10+k3s1
+          #   crictl: v1.17.0
+          # - runtime: K3s-1.20
+          #   version: v1.20.6+k3s1
+          #   crictl: v1.17.0
+          # - runtime: Kubernetes-1.16
+          #   version: 1.16.15-00
+          #   crictl: UNUSED
+          # - runtime: Kubernetes-1.17
+          #   version: 1.17.14-00
+          #   crictl: UNUSED
+          # - runtime: Kubernetes-1.18
+          #   version: 1.18.12-00
+          #   crictl: UNUSED
+          # - runtime: Kubernetes-1.19
+          #   version: 1.19.4-00
+          #   crictl: UNUSED
+          # - runtime: Kubernetes-1.20
+          #   version: 1.20.1-00
+          #   crictl: UNUSED
+          # - runtime: Kubernetes-1.21
+          #   version: 1.21.0-00
+          #   crictl: UNUSED
         test:
           - case: end-to-end
             file: test/run-end-to-end.py
@@ -193,8 +202,8 @@ jobs:
 
       - if: startsWith(matrix.kube.runtime, 'K3s')
         name: Install K3s
-        env:
-          INSTALL_K3S_VERSION: ${{ matrix.kube.version }}
+        # env:
+        #   INSTALL_K3S_VERSION: ${{ matrix.kube.version }}
         run: |
           sudo curl -sfL https://get.k3s.io -o install.sh
           sudo chmod +x install.sh
@@ -236,7 +245,7 @@ jobs:
           sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
           echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt-get update
-          sudo apt-get install -o Dpkg::Options::="--force-overwrite" -y --allow-downgrades kubelet=${{ matrix.kube.version }} kubeadm=${{ matrix.kube.version }} kubectl=${{ matrix.kube.version }} 
+          sudo apt-get install -o Dpkg::Options::="--force-overwrite" -y --allow-downgrades kubelet kubeadm kubectl
           kubectl version && echo "kubectl return code: $?" || echo "kubectl return code: $?"
           kubeadm version && echo "kubeadm return code: $?" || echo "kubeadm return code: $?"
           kubelet --version && echo "kubelet return code: $?" || echo "kubelet return code: $?"
@@ -262,7 +271,7 @@ jobs:
         name: Install MicroK8s
         run: |
           set -x
-          sudo snap install microk8s --classic --channel=${{ matrix.kube.version }}
+          sudo snap install microk8s --classic
           sudo microk8s status --wait-ready
           sudo usermod -a -G microk8s $USER
           sudo ls -la $HOME/.kube

--- a/.github/workflows/run-test-cases.yml
+++ b/.github/workflows/run-test-cases.yml
@@ -248,7 +248,7 @@ jobs:
           sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
           echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
           sudo apt-get update
-          sudo apt-get install -o Dpkg::Options::="--force-overwrite" -y --allow-downgrades kubelet kubeadm kubectl
+          sudo apt-get install -y --allow-downgrades kubelet kubeadm kubectl
           kubectl version && echo "kubectl return code: $?" || echo "kubectl return code: $?"
           kubeadm version && echo "kubeadm return code: $?" || echo "kubeadm return code: $?"
           kubelet --version && echo "kubelet return code: $?" || echo "kubelet return code: $?"


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
This is testing our e2e tests on the latest 1.22 Kubernetes version on all 3 distributions.
Then it will add it to our test matrix.
This is in preparation for a release.