### PR TITLE
Fix how duplicates are handled in ONVIF [SAME VERSION]

### DIFF
--- a/discovery-handlers/onvif/src/discovery_impl.rs
+++ b/discovery-handlers/onvif/src/discovery_impl.rs
@@ -134,6 +134,7 @@ pub mod util {
     use super::{common, probe_types, to_deserialize, to_serialize};
     use akri_discovery_utils::filtering::{FilterList, FilterType};
     use log::{error, info, trace};
+    use std::collections::HashSet;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use tokio::{
         io::ErrorKind,
@@ -202,7 +203,10 @@ pub mod util {
             .collect::<Vec<String>>()
     }
 
-    async fn get_responsive_uris(uris: Vec<String>, onvif_query: &impl OnvifQuery) -> Vec<String> {
+    async fn get_responsive_uris(
+        uris: HashSet<String>,
+        onvif_query: &impl OnvifQuery,
+    ) -> Vec<String> {
         let futures: Vec<_> = uris
             .iter()
             .map(|uri| onvif_query.is_device_responding(uri))
@@ -310,7 +314,7 @@ pub mod util {
         scopes_filters: Option<&FilterList>,
         timeout: Duration,
     ) -> Result<Vec<String>, anyhow::Error> {
-        let mut broadcast_responses = std::collections::HashSet::new();
+        let mut broadcast_responses = Vec::new();
 
         let start = Instant::now();
         loop {
@@ -323,7 +327,7 @@ pub mod util {
 
             match try_recv_string(socket, time_left).await {
                 Ok(s) => {
-                    broadcast_responses.insert(s.to_lowercase());
+                    broadcast_responses.push(s);
                 }
                 Err(e) => match e.kind() {
                     ErrorKind::WouldBlock | ErrorKind::TimedOut => {
@@ -341,7 +345,7 @@ pub mod util {
             "simple_onvif_discover - uris discovered by udp broadcast {:?}",
             broadcast_responses
         );
-        let mut filtered_uris = Vec::new();
+        let mut filtered_uris = std::collections::HashSet::new();
         broadcast_responses.into_iter().for_each(|r| {
             filtered_uris.extend(get_scope_filtered_uris_from_discovery_response(
                 &r,


### PR DESCRIPTION
<!--  Thank you for contributing to the Akri repo! Before submitting this PR, please make sure:
1. Read the Contributing Guide before submitting your PR: https://docs.akri.sh/community/contributing
2. Decide whether you need to add any flags to your PR title, such as `[SAME VERSION]` if the version should not be changed and your change will trigger the version check workflow. This will cause the workflow to automatically succeed: https://github.com/deislabs/akri/blob/main/.github/workflows/check-versioning.yml
3. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context. -->

**What this PR does / why we need it**:
There is an ONVIF discovery bug caused by this PR https://github.com/deislabs/akri/pull/382, which means that ONVIF discovery doesn't work for Akri versions 0.6.17-0.6.19. Any thoughts on how this should be handled? This is further compounded by the fact that I discovered this after creating the release, so currently latest points to 0.6.19 which means `helm install akri akri-helm-charts/akri` installs the faulty version. 

My proposed fix: push this fix as version 0.6.19 and create new release and in the release CHANGELOG (see #394) put that ONVIF discovery does not work in versions 0.6.17 and 0.6.18 .

Thoughts?

**Special notes for your reviewer**:
The bug was caused by the fact that we were applying `to_lowercase()` on xml strings to be passed to later parts of discovery and leaving cameras un-discovered. To fix this, this PR removes duplicates on only the URIs returned from `get_scope_filtered_uris_from_discovery_response` is more ideal.
Example of issue: original string:
```
<?xml version="1.0" encoding="UTF-8"?>
    <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://www.w3.org/2003/05/soap-encoding" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsdd="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:tdn="http://www.onvif.org/ver10/network/wsdl"><SOAP-ENV:Header><wsa:MessageID>urn:uuid:b7b46c8b-16e3-4b77-920e-edd1374a3fe6</wsa:MessageID><wsa:RelatesTo>uuid:b800c7f9-24b5-4817-b87d-446e8fb76e49</wsa:RelatesTo><wsa:ReplyTo SOAP-ENV:mustUnderstand="true"><wsa:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:Address></wsa:ReplyTo><wsa:To SOAP-ENV:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:To><wsa:Action SOAP-ENV:mustUnderstand="true">http://schemas.xmlsoap.org/ws/2005/04/discovery/ProbeMatches</wsa:Action><wsdd:AppSequence InstanceId="0" MessageNumber="36"></wsdd:AppSequence></SOAP-ENV:Header><SOAP-ENV:Body><wsdd:ProbeMatches><wsdd:ProbeMatch><wsa:EndpointReference><wsa:Address>urn:uuid:fb03dab7-1787-4e12-ab8b-4567327b23c6</wsa:Address></wsa:EndpointReference><wsdd:Types>tdn:NetworkVideoTransmitter</wsdd:Types><wsdd:Scopes>onvif://www.onvif.org/name/Unknown onvif://www.onvif.org/Profile/Streaming</wsdd:Scopes><wsdd:XAddrs>http://10.0.0.4:1000/onvif/device_service</wsdd:XAddrs><wsdd:MetadataVersion>0</wsdd:MetadataVersion></wsdd:ProbeMatch></wsdd:ProbeMatches></SOAP-ENV:Body></SOAP-ENV:Envelope>
```
And after `to_lowercase()`:
```
<?xml version="1.0" encoding="utf-8"?>
    <soap-env:envelope xmlns:soap-env="http://www.w3.org/2003/05/soap-envelope" xmlns:soap-enc="http://www.w3.org/2003/05/soap-encoding" xmlns:xsi="http://www.w3.org/2001/xmlschema-instance" xmlns:xsd="http://www.w3.org/2001/xmlschema" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsdd="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:tdn="http://www.onvif.org/ver10/network/wsdl"><soap-env:header><wsa:messageid>urn:uuid:b7b46c8b-16e3-4b77-920e-edd1374a3fe6</wsa:messageid><wsa:relatesto>uuid:b800c7f9-24b5-4817-b87d-446e8fb76e49</wsa:relatesto><wsa:replyto soap-env:mustunderstand="true"><wsa:address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:address></wsa:replyto><wsa:to soap-env:mustunderstand="true">http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:to><wsa:action soap-env:mustunderstand="true">http://schemas.xmlsoap.org/ws/2005/04/discovery/probematches</wsa:action><wsdd:appsequence instanceid="0" messagenumber="36"></wsdd:appsequence></soap-env:header><soap-env:body><wsdd:probematches><wsdd:probematch><wsa:endpointreference><wsa:address>urn:uuid:fb03dab7-1787-4e12-ab8b-4567327b23c6</wsa:address></wsa:endpointreference><wsdd:types>tdn:networkvideotransmitter</wsdd:types><wsdd:scopes>onvif://www.onvif.org/name/unknown onvif://www.onvif.org/profile/streaming</wsdd:scopes><wsdd:xaddrs>http://10.0.0.4:1000/onvif/device_service</wsdd:xaddrs><wsdd:metadataversion>0</wsdd:metadataversion></wsdd:probematch></wsdd:probematches></soap-env:body></soap-env:envelope>
```
**If applicable**:
- [ ] this PR has an associated PR with documentation in [akri-docs](https://github.com/deislabs/akri-docs)
- [ ] this PR contains unit tests
- [ ] added code adheres to standard Rust formatting (`cargo fmt`)
- [ ] code builds properly (`cargo build`)
- [ ] code is free of common mistakes (`cargo clippy`)
- [ ] all Akri tests succeed (`cargo test`)
- [ ] inline documentation builds (`cargo doc`)
- [ ] version has been updated appropriately (`./version.sh`)